### PR TITLE
fix(findings): reject non-integer and out-of-range line numbers

### DIFF
--- a/source/findings/types.ts
+++ b/source/findings/types.ts
@@ -14,6 +14,14 @@ export const CONFIDENCES = ['low', 'medium', 'high'] as const;
 
 export type Confidence = (typeof CONFIDENCES)[number];
 
+/**
+ * The ceiling on a cited line number. No real source file comes close, so a
+ * value above it is a hallucinated number rather than a location. It sits here
+ * beside the other contract constants because both ends need it: the prompt
+ * advertises the bound and the validator enforces it.
+ */
+export const MAX_LINE = 10_000_000;
+
 /** A 1-indexed, inclusive line range within a file. */
 export interface LineRange {
 	start: number;

--- a/source/findings/validate.spec.ts
+++ b/source/findings/validate.spec.ts
@@ -1,5 +1,6 @@
 import test from 'ava';
-import {validateFindings} from './validate.js';
+import {MAX_LINE} from './types.js';
+import {type ValidationError, validateFindings} from './validate.js';
 
 console.log('\nfindings/validate.spec.ts');
 
@@ -102,30 +103,63 @@ test('rejects an inverted line range', t => {
 // A model that hallucinates a line number tends to emit one of these. They all
 // slip past a bare `typeof === 'number'` gate, and a finding carrying one
 // renders a `file:start` reference in the issue body that points nowhere.
-const BAD_LINE_NUMBERS: Array<[string, unknown]> = [
+//
+// The cases are split by the gate that actually rejects them, and each asserts
+// on the message rather than just the field: a value that drifts to the other
+// gate then fails loudly instead of passing for the wrong reason.
+
+/** Rejected by the `Number.isInteger` gate. */
+const NON_INTEGER_LINE_NUMBERS: Array<[string, unknown]> = [
 	['Infinity', Number.POSITIVE_INFINITY],
 	['-Infinity', Number.NEGATIVE_INFINITY],
 	['NaN', Number.NaN],
-	['1e20', 1e20],
-	['-0', -0],
 	['1.5', 1.5],
+	// Not from the issue: a guard on dropping the old `typeof` gate, which is
+	// the one thing that kept strings out.
 	['a numeric string', '42'],
 ];
 
-for (const [label, value] of BAD_LINE_NUMBERS) {
-	test(`rejects a line range of ${label}`, t => {
+/**
+ * Integral, so past the integer gate; rejected instead by the bound
+ * 1 <= start <= end <= MAX_LINE.
+ */
+const OUT_OF_RANGE_LINE_NUMBERS: Array<[string, unknown]> = [
+	// Number.isInteger(-0) is true, so only the lower bound catches it.
+	['-0', -0],
+	['1e20', 1e20],
+];
+
+function lineRangeMessage(errors: ValidationError[]): string {
+	return errors.find(e => e.field === 'line_range')?.message ?? '';
+}
+
+for (const [label, value] of NON_INTEGER_LINE_NUMBERS) {
+	test(`rejects a line range of ${label} as a non-integer`, t => {
 		const result = validateFindings([
 			validFinding({line_range: {start: value, end: value}}),
 		]);
 		t.false(result.valid);
-		t.true(result.errors.some(e => e.field === 'line_range'));
 		t.is(result.findings.length, 0);
+		t.true(lineRangeMessage(result.errors).includes('must both be integers'));
 	});
 }
 
+for (const [label, value] of OUT_OF_RANGE_LINE_NUMBERS) {
+	test(`rejects a line range of ${label} as out of range`, t => {
+		const result = validateFindings([
+			validFinding({line_range: {start: value, end: value}}),
+		]);
+		t.false(result.valid);
+		t.is(result.findings.length, 0);
+		t.true(lineRangeMessage(result.errors).includes('must satisfy'));
+	});
+}
+
+// MAX_LINE is imported rather than written out so retuning the constant cannot
+// leave this pair passing while no longer straddling the boundary.
 test('accepts a line range sitting on the upper bound', t => {
 	const result = validateFindings([
-		validFinding({line_range: {start: 1, end: 10_000_000}}),
+		validFinding({line_range: {start: 1, end: MAX_LINE}}),
 	]);
 	t.true(result.valid);
 	t.is(result.findings.length, 1);
@@ -133,10 +167,10 @@ test('accepts a line range sitting on the upper bound', t => {
 
 test('rejects a line range one past the upper bound', t => {
 	const result = validateFindings([
-		validFinding({line_range: {start: 1, end: 10_000_001}}),
+		validFinding({line_range: {start: 1, end: MAX_LINE + 1}}),
 	]);
 	t.false(result.valid);
-	t.true(result.errors.some(e => e.field === 'line_range'));
+	t.true(lineRangeMessage(result.errors).includes('must satisfy'));
 });
 
 test('rejects an invalid confidence value', t => {

--- a/source/findings/validate.spec.ts
+++ b/source/findings/validate.spec.ts
@@ -99,6 +99,46 @@ test('rejects an inverted line range', t => {
 	t.true(result.errors.some(e => e.field === 'line_range'));
 });
 
+// A model that hallucinates a line number tends to emit one of these. They all
+// slip past a bare `typeof === 'number'` gate, and a finding carrying one
+// renders a `file:start` reference in the issue body that points nowhere.
+const BAD_LINE_NUMBERS: Array<[string, unknown]> = [
+	['Infinity', Number.POSITIVE_INFINITY],
+	['-Infinity', Number.NEGATIVE_INFINITY],
+	['NaN', Number.NaN],
+	['1e20', 1e20],
+	['-0', -0],
+	['1.5', 1.5],
+	['a numeric string', '42'],
+];
+
+for (const [label, value] of BAD_LINE_NUMBERS) {
+	test(`rejects a line range of ${label}`, t => {
+		const result = validateFindings([
+			validFinding({line_range: {start: value, end: value}}),
+		]);
+		t.false(result.valid);
+		t.true(result.errors.some(e => e.field === 'line_range'));
+		t.is(result.findings.length, 0);
+	});
+}
+
+test('accepts a line range sitting on the upper bound', t => {
+	const result = validateFindings([
+		validFinding({line_range: {start: 1, end: 10_000_000}}),
+	]);
+	t.true(result.valid);
+	t.is(result.findings.length, 1);
+});
+
+test('rejects a line range one past the upper bound', t => {
+	const result = validateFindings([
+		validFinding({line_range: {start: 1, end: 10_000_001}}),
+	]);
+	t.false(result.valid);
+	t.true(result.errors.some(e => e.field === 'line_range'));
+});
+
 test('rejects an invalid confidence value', t => {
 	const result = validateFindings([validFinding({confidence: 'certain'})]);
 	t.false(result.valid);

--- a/source/findings/validate.ts
+++ b/source/findings/validate.ts
@@ -47,6 +47,17 @@ function isNonEmptyString(value: unknown): value is string {
 	return typeof value === 'string' && value.trim().length > 0;
 }
 
+/** Rejects non-numbers along with NaN, +/-Infinity and fractional values. */
+function isInteger(value: unknown): value is number {
+	return Number.isInteger(value);
+}
+
+/**
+ * The ceiling on a cited line number. No real source file comes close, so a
+ * value above it is a hallucinated number rather than a location.
+ */
+const MAX_LINE = 10_000_000;
+
 function validateLineRange(
 	value: unknown,
 	index: number,
@@ -56,26 +67,26 @@ function validateLineRange(
 		errors.push({
 			index,
 			field: 'line_range',
-			message: 'line_range must be an object with numeric start and end',
+			message: 'line_range must be an object with integer start and end',
 		});
 		return false;
 	}
 
 	const {start, end} = value;
-	if (typeof start !== 'number' || typeof end !== 'number') {
+	if (!isInteger(start) || !isInteger(end)) {
 		errors.push({
 			index,
 			field: 'line_range',
-			message: 'line_range.start and line_range.end must both be numbers',
+			message: 'line_range.start and line_range.end must both be integers',
 		});
 		return false;
 	}
 
-	if (start < 1 || end < start) {
+	if (start < 1 || end < start || end > MAX_LINE) {
 		errors.push({
 			index,
 			field: 'line_range',
-			message: 'line_range must satisfy 1 <= start <= end',
+			message: `line_range must satisfy 1 <= start <= end <= ${MAX_LINE}`,
 		});
 		return false;
 	}

--- a/source/findings/validate.ts
+++ b/source/findings/validate.ts
@@ -17,6 +17,7 @@ import {
 	isConfidence,
 	isSeverity,
 	type LineRange,
+	MAX_LINE,
 	type Severity,
 } from './types.js';
 
@@ -51,12 +52,6 @@ function isNonEmptyString(value: unknown): value is string {
 function isInteger(value: unknown): value is number {
 	return Number.isInteger(value);
 }
-
-/**
- * The ceiling on a cited line number. No real source file comes close, so a
- * value above it is a hallucinated number rather than a location.
- */
-const MAX_LINE = 10_000_000;
 
 function validateLineRange(
 	value: unknown,

--- a/source/prompt/build.spec.ts
+++ b/source/prompt/build.spec.ts
@@ -1,4 +1,5 @@
 import test from 'ava';
+import {MAX_LINE} from '../findings/types.js';
 import type {RulePack} from '../rule-packs/types.js';
 import {buildAuditPrompt} from './build.js';
 
@@ -70,6 +71,18 @@ test('states the snake_case reporting contract with the allowed scales', t => {
 	t.true(prompt.includes('"low", "medium", "high", "critical"'));
 	t.true(prompt.includes('"low", "medium", "high"'));
 	t.true(prompt.includes('Return [] if you find nothing.'));
+});
+
+// The validator is the hard gate, but a prompt describing a looser contract
+// than it enforces costs a whole model run before anything gets filed. Pin the
+// two together: line numbers are integers, bounded by the same MAX_LINE.
+test('advertises the line_range bounds the validator enforces', t => {
+	const {prompt} = buildAuditPrompt({
+		pack: pack(),
+		files: [{path: 'programs/x.rs', content: 'x'}],
+	});
+	t.true(prompt.includes('{"start": <integer>, "end": <integer>}'));
+	t.true(prompt.includes(`1 <= start <= end <= ${MAX_LINE}`));
 });
 
 test('renders severity weighting when present', t => {

--- a/source/prompt/build.ts
+++ b/source/prompt/build.ts
@@ -6,7 +6,7 @@
  * {@link ../findings/validate.js validator} accepts.
  */
 
-import {CONFIDENCES, SEVERITIES} from '../findings/types.js';
+import {CONFIDENCES, MAX_LINE, SEVERITIES} from '../findings/types.js';
 import {matchesAppliesTo} from '../rule-packs/glob.js';
 import type {PromptInput, PromptResult, SourceFile} from './types.js';
 
@@ -40,7 +40,7 @@ function reportingContract(packName: string, category: string): string {
 		'',
 		`- "rule": string — the pack rule that fired, prefixed with the pack name (e.g. "${packName}/<pattern>")`,
 		'- "file": string — the repository-relative path of the affected file',
-		'- "line_range": object — {"start": <number>, "end": <number>}, 1-indexed and inclusive',
+		`- "line_range": object — {"start": <integer>, "end": <integer>}, 1-indexed and inclusive, with 1 <= start <= end <= ${MAX_LINE}`,
 		`- "category": string — the finding category (e.g. "${category || packName}")`,
 		`- "severity": string — one of ${quotedList(SEVERITIES)}`,
 		`- "confidence": string — one of ${quotedList(CONFIDENCES)}`,


### PR DESCRIPTION
## Description

`validateLineRange` gated on `typeof === 'number'`, which lets `Infinity`, `NaN`
and fractional values through: `start < 1 || end < start` is false for all of
them, so a hallucinated `line_range` validated cleanly and the issue body
rendered a `file:start` reference pointing nowhere. The dedup hash ignores line
numbers, so nothing downstream caught it either.

Swap the type gate for `Number.isInteger` which rejects `NaN`, `±Infinity`
and `1.5` in one check — and hang an upper bound (`MAX_LINE = 10_000_000`) off
the existing ordering check so absurd-but-integral values like `1e20` are
rejected too. The two checks stay separate so the auto-fix loop gets a specific
reason ("must both be integers" vs "must satisfy 1 <= start <= end <= 10000000")
rather than one vague message.

Two deliberate deviations from the issue text, both verified rather than assumed:

- The issue also asks for `!Number.isFinite(...)`. Every non-finite number is
  already a non-integer, so that check is redundant on top of `Number.isInteger`
  rather than missing. Left out as dead code.
- The issue proposes the ceiling as `start > 10_000_000`; this checks `end`.
  Because `end >= start` is enforced immediately before, `start > MAX` implies
  `end > MAX`, so checking `end` is a strict superset it also catches a valid
  `start` paired with an absurd `end`.

`-0` and `-Infinity` already failed the `start < 1` bound; they are covered by
tests now so a future refactor of that bound cannot drop them silently.

Closes #6

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Modification to existing behaviour
- [ ] Documentation
- [ ] Refactor / chore

## Testing

<!-- How you verified this. -->

- [x] `pnpm test:all` passes locally.
- [x] Added or updated tests for the change.
- Manual testing notes:
  - Added a table-driven case per value from the issue `Infinity`,
    `-Infinity`, `NaN`, `1e20`, `-0`, `1.5` plus a numeric-string case (a
    regression guard, since removing the `typeof` gate is what would otherwise
    let a string through), plus boundary tests at exactly `MAX_LINE` and one
    past it (nothing else covers `>` vs `>=`).
  - Confirmed the tests fail against the unfixed validator: `Infinity`, `NaN`,
    `1e20`, `1.5` and the ceiling case all fail without the change. `-0` and
    `-Infinity` pass either way, as noted in the issue thread.
  - Traced completeness: `validate.ts` is the only place `lineRange` is
    constructed and `orchestrator/audit.ts` its only caller, so there is no
    second path by which a bogus line number can reach the issue body, the
    per-issue footer, the dry-run preview, or the run report.
  - Coverage: `validate.ts` at 97.14% lines; both new branches covered.
  - Note for Windows contributors: with `core.autocrlf=true`, `test:format` and
    the `template-sync` specs fail locally on line endings alone. Verified
    against an LF worktree (what CI checks out) where Biome exits 0 and every
    `template/` file byte-matches the scaffolder output.

## Checklist

- [x] Follows the existing code style (Biome-formatted).
- [x] I have self-reviewed the diff.
- [x] Docs updated if user-visible behaviour changed.
- [x] No secrets, tokens, or private source committed.
- [x] Contract surfaces (`sentinel.yaml` schema, rule-pack manifest, findings
      model) if changed, the docs and the relevant spec are updated in this PR.
- [x] Breaking changes are called out above.

Notes on the last three:

- No docs change needed. The three hard rules in `docs/workflow/index.md` and
  the `line_range` row in `docs/findings/index.md` remain accurate this
  tightens enforcement of an existing rule rather than adding one.
- The `LineRange` interface is unchanged (`{start: number; end: number}`); only
  validation is tightened, and `findings/validate.spec.ts` is updated here.
- `ValidationError` and the `ValidationResult` shape are untouched, so nothing
  downstream of `validateFindings` moves. The one behavioural change worth
  naming: output that previously validated with a garbage `line_range` now
  fails and triggers the auto-fix pass instead of filing an issue which is
  the point of the fix.
