### PR TITLE
ci: replace local PR checks with the shared org workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,144 +1,18 @@
 name: Pull Request Automated Checks
 
+# Thin caller for the shared org workflow. Everything lives in
+# Nano-Collective/.github — change it there and every repo picks it up.
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [main]
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 jobs:
-  test-lint:
-    name: Linting
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - name: Install pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
-        with:
-          node-version: '22'
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Run linting
-        run: pnpm test:lint
-
-  test-format:
-    name: Format Checks
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - name: Install pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
-        with:
-          node-version: '22'
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Run format check
-        run: pnpm test:format
-
-  test-types:
-    name: Type Checks
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - name: Install pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
-        with:
-          node-version: '22'
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Run type checking
-        run: pnpm test:types
-
-  test-unit:
-    name: Tests + Coverage
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - name: Install pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
-        with:
-          node-version: '22'
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Run tests with coverage
-        run: pnpm test:ava:coverage
-
-  test-build:
-    name: Build Verification
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - name: Install pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
-        with:
-          node-version: '22'
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Build
-        run: pnpm build
-
-  test-knip:
-    name: Unused Code (Knip)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - name: Install pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
-        with:
-          node-version: '22'
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Check for unused code
-        run: pnpm test:knip
-
-  test-audit:
-    name: Dependency Audit
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - name: Install pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
-        with:
-          node-version: '22'
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Run dependency audit
-        run: pnpm test:audit
-
-  test-security:
-    name: Security Scan (Semgrep)
-    runs-on: ubuntu-latest
-    container:
-      image: semgrep/semgrep
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - name: Run Semgrep
-        run: semgrep scan --config auto --error
+  pr-checks:
+    uses: Nano-Collective/.github/.github/workflows/pr-checks.yml@main


### PR DESCRIPTION
Second repo onto the shared `pr-checks` workflow in `Nano-Collective/.github`, after [get-md#29](https://github.com/Nano-Collective/get-md/pull/29).

### Why this one is worth doing early

`sentinel` carried its own 150-line `pr-checks.yml` running the same checks as every other repo under **different job names**:

| This repo called it | Everywhere else |
|---|---|
| `Tests + Coverage` | `Unit Tests & Coverage Analysis` |
| `Build Verification` | `Verify Build` |
| `Unused Code (Knip)` | `Unused Dependencies` |
| `Dependency Audit` | `Package Audit Analysis` |
| `Security Scan (Semgrep)` | `Semgrep Security Scan` |

That naming drift is the specific reason the org quality ruleset cannot currently require one set of checks across repos — required status checks match on name. This repo has no ruleset today, so nothing references the old names and the rename is safe.

### What the shared workflow does

**Blocking** — Linting, Type Checks, Format Checks, Unused Dependencies, Unit Tests & Coverage Analysis, Verify Build. These become the required checks under the org quality ruleset.

**Advisory** — Package Audit Analysis, Semgrep Security Scan, CodeQL Security Analysis. They run and report but never fail the PR, because they depend on upstream advisory feeds and a disclosure landing overnight should not block an unrelated bug fix.

Coverage here is **96.19%**, comfortably above the 80% floor. The workflow also enforces fail-on-drop, reading the baseline from the committed coverage badge on `main`.

### Note

`sentinel` already used the `semgrep/semgrep` container for its security scan, which is the correct approach — the shared workflow does the same. An earlier revision of it tried calling `pnpm test:security` from a bare runner and failed, since that script assumes semgrep is already on PATH.
