### PR TITLE
chore: own code through the core team, not individuals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
-# Default owner for everything in the repo.
-* @will-lamerton
+# Ownership is held by the team, not by individuals: adding a maintainer is a
+# team membership change rather than a pull request against seven files.
+* @Nano-Collective/core-team


### PR DESCRIPTION
Implements step 6 of the ops scaling work.

## Why

`Review gates` sets `require_code_owner_review: true`. A repository with **no** `CODEOWNERS` satisfies that requirement vacuously — there is no owner, so there is nothing to review. `nanotune` and `nanoterm` were in that state.

Where a `CODEOWNERS` did exist, it named a single person on `sentinel`, `get-md` and `json-up`. Sole ownership is the bottleneck this whole piece of work exists to remove.

## Why the team rather than names

`@Nano-Collective/core-team` holds `maintain` on all seven package repositories, which satisfies GitHub's write-access requirement for a team code owner.

Using the team means adding a maintainer is one team membership change, not seven pull requests against seven `CODEOWNERS` files that will drift apart. It is the same reasoning that moved repository access onto teams in the first place.
