### PR TITLE
fix(release): enter changesets pre mode so the alpha series survives

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -20,3 +20,25 @@ use `pnpm changeset --empty`.
 Changesets accumulate on `main` until the **Version Packages** pull request is
 merged, which bumps the version and rolls the entries into `CHANGELOG.md`.
 Merging that pull request is what triggers a release.
+
+## Pre mode — read this before cutting v1
+
+`pre.json` puts this repository in changesets' **pre mode**, tagged `alpha`. It
+is load-bearing, not decoration. Without it `changeset version` treats
+`0.1.0-alpha.3` as an ordinary prerelease to be resolved, and a single patch
+changeset bumps it to **`0.1.0`** — so the first Version PR merged would ship
+v1, claim npm's `latest` tag, and skip the rest of the alpha series in one go.
+
+In pre mode the same changeset bumps `0.1.0-alpha.3` → `0.1.0-alpha.4`, which is
+what the [roadmap](../ROADMAP.md) expects for every release up to v1.
+
+**Cutting `1.0.0` is therefore a deliberate two-step**, not the absence of a
+step:
+
+```bash
+pnpm changeset pre exit   # deletes pre.json
+pnpm changeset version    # 0.1.0-alpha.N -> 1.0.0
+```
+
+Do that only when the roadmap's phase 3 is complete. Deleting `pre.json` at any
+other time releases v1 by accident.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,4 @@
+{
+  "mode": "pre",
+  "tag": "alpha"
+}

--- a/biome.json
+++ b/biome.json
@@ -13,7 +13,8 @@
 			"!coverage",
 			"!node_modules",
 			"!.husky",
-			"!template"
+			"!template",
+			"!.changeset/pre.json"
 		]
 	},
 	"formatter": {


### PR DESCRIPTION
## The problem

Adopting changesets in #19 left the repository out of changesets' **pre mode**. `changeset version` therefore treats `0.1.0-alpha.3` as a prerelease to be *resolved*, not continued — so a single patch changeset takes it to `0.1.0`.

The consequence is that **the first Version Packages PR merged would have shipped v1**: `release.yml` derives the npm dist-tag from the version string, so `0.1.0` publishes as `latest`, claims the tag permanently, and skips phases 1–3 of `ROADMAP.md` in a single merge. Nothing in the pipeline would have questioned it — the Version PR looks routine.

Nothing has triggered it yet only because no changeset has landed since #19.

## Verified, not inferred

Ran `changeset version` against a copy of this repo's `.changeset/` and `package.json` on `@changesets/cli 3.0.1`, with and without `pre.json`:

| | `0.1.0-alpha.3` becomes |
|---|---|
| without `pre.json` (today) | **`0.1.0`** |
| with `pre.json` (this PR) | **`0.1.0-alpha.4`** |

`pre.json` is the tool's own output from `changeset pre enter alpha`, not hand-written.

## The second trap, fixed in the same change

`changeset version` **rewrites `pre.json` with two-space indentation** on every run. With that file in Biome's scope, the generated Version PR fails `test:format` — a blocking required status check under Ruleset A — so it could never merge, and the failure would read as a formatting nit rather than a tooling conflict.

`.changeset/pre.json` is therefore excluded from Biome. `package.json` needs no equivalent exclusion: changesets detects and preserves its existing tab indentation (checked).

## Cutting v1 is now a deliberate step

`.changeset/README.md` records it, because the failure mode is silent in the other direction too — deleting `pre.json` at the wrong moment releases v1 by accident:

```bash
pnpm changeset pre exit   # deletes pre.json
pnpm changeset version    # 0.1.0-alpha.N -> 1.0.0
```

## Notes

- No changeset in this PR: release plumbing, not a user-facing package change.
- Full gate green locally — 336 tests, types, lint, format, knip.
