### PR TITLE
fix(ci): typecheck specs so contract breaks reach the gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"test:ava": "ava",
 		"test:ava:coverage": "c8 ava",
 		"test:format": "biome check --no-errors-on-unmatched .",
-		"test:types": "tsc --noEmit",
+		"test:types": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
 		"test:lint": "biome lint .",
 		"test:lint:fix": "biome check --write --unsafe .",
 		"test:knip": "knip",

--- a/source/run/estimate.spec.ts
+++ b/source/run/estimate.spec.ts
@@ -592,6 +592,7 @@ test('renders large figures compactly', t => {
 				repo: 'my-org/a',
 				packs: ['p'],
 				files: 1204,
+				checkedOut: true,
 				requests: 420,
 				tokens: 3_800_000,
 				durationMs: 14 * 60_000,
@@ -608,6 +609,7 @@ test('renders large figures compactly', t => {
 		},
 		calibration: {
 			msPerRequest: 2000,
+			msPerPromptToken: 10,
 			requestsPerPass: 1,
 			outputTokensPerRequest: 700,
 			samples: 3,
@@ -701,6 +703,7 @@ test('warns about missing packs, unparseable packs, and target errors', t => {
 		},
 		calibration: {
 			msPerRequest: 1000,
+			msPerPromptToken: 10,
 			requestsPerPass: 1,
 			outputTokensPerRequest: 100,
 			samples: 1,

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+	// Type checking only — never built. The base config excludes specs so that
+	// `tsc && tsc-alias` keeps them out of dist/; this config drops that exclude
+	// so `test:types` still sees them. Specs are usually the first place a
+	// contract change shows up, and without this the gate cannot see it.
+	"extends": "./tsconfig.json",
+	"exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
Closes #16.

## What was wrong

`tsconfig.json` excludes `source/**/*.spec.ts` so that `tsc && tsc-alias` keeps specs out of `dist/`. `test:types` ran that same config, so **the type gate never looked at a single spec file** — and specs are usually the first place a contract change shows up.

## The fix

`tsconfig.test.json` extends the base config and drops only that exclude. `test:types` now runs both:

```
tsc --noEmit && tsc --noEmit -p tsconfig.test.json
```

The base config still verifies exactly what ships; the test config covers everything else. The build is untouched — checked that `dist/` still contains zero `*.spec.*` files.

This is the first of the two options in the issue, chosen because it leaves the build config alone.

## Three real errors surfaced immediately

All the exact failure #16 describes — stale object literals that kept compiling after #14 added required fields:

| Site | Missing |
|---|---|
| `estimate.spec.ts:591` | `RepoEstimate.checkedOut` |
| `estimate.spec.ts:609` | `Calibration.msPerPromptToken` |
| `estimate.spec.ts:702` | `Calibration.msPerPromptToken` |

The first was not merely cosmetic. `caveats()` filters on `!repo.checkedOut`, so with the field `undefined` that test was silently exercising the *"1 repo(s) are not checked out"* path while claiming to test compact number formatting. It asserted only on the formatted figures, so it passed either way.

## Proof the gate now does its job

Temporarily added a required field to an exported interface (`LineRange` in `source/findings/types.ts`) and ran both configs:

| Gate | Result |
|---|---|
| old — base config only | **exit 0, 0 errors** |
| new — with `tsconfig.test.json` | **exit 2, 10 errors** |

```
source/dedup/hash.spec.ts(11,3): error TS2741: Property 'probeField' is missing in type '{ start: number; end: number; }' but required in type 'LineRange'.
...
```

Reverted after the check.

## Notes

- No changeset: repository tooling and test fixes, no runtime change.
- Full gate green locally — 336 tests, types, lint, format, knip, build.
