### PR TITLE
ci: call the shared update-badges workflow

### DIFF
--- a/.github/workflows/update-badges.yml
+++ b/.github/workflows/update-badges.yml
@@ -1,9 +1,20 @@
 name: Update Status Badges
 
+# Thin caller for the shared org workflow. Everything lives in
+# Nano-Collective/.github — change it there and every repo picks it up on its
+# next run.
+#
+# PAT_TOKEN is how the push gets past the branch rulesets. It is optional in the
+# shared workflow, but without it the push is made as github-actions[bot], which
+# the rulesets will refuse: adding the built-in Actions integration as a bypass
+# actor is rejected by GitHub with "Actor GitHub Actions integration must be
+# part of the ruleset source or owner organization" (tested 2026-09-07). So for
+# now every repo needs the secret.
+
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * *" # daily at midnight UTC
+    - cron: '0 0 * * *' # daily at midnight UTC
   release:
     types: [published]
 
@@ -11,82 +22,10 @@ permissions:
   contents: write
 
 jobs:
-  generate-badges:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          token: ${{ secrets.PAT_TOKEN }}
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: "22"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build
-        run: pnpm build
-
-      - name: Run tests for latest coverage
-        run: pnpm test:ava:coverage || echo "Coverage test failed or not available"
-
-      - name: Extract coverage
-        id: coverage
-        run: |
-          if [ -f "coverage/coverage-summary.json" ]; then
-            COVERAGE=$(cat coverage/coverage-summary.json | jq -r '.total.lines.pct // "N/A"')
-            echo "percentage=${COVERAGE}" >> $GITHUB_OUTPUT
-          else
-            echo "percentage=N/A" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Check build status
-        id: build
-        run: |
-          if pnpm build; then
-            echo "status=passing" >> $GITHUB_OUTPUT
-            echo "color=brightgreen" >> $GITHUB_OUTPUT
-          else
-            echo "status=failing" >> $GITHUB_OUTPUT
-            echo "color=red" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Generate badges
-        run: |
-          mkdir -p badges
-          STYLE="style=for-the-badge"
-
-          if [ "${{ steps.coverage.outputs.percentage }}" != "N/A" ]; then
-            PCT="${{ steps.coverage.outputs.percentage }}"
-            COLOR=$(echo "${PCT}" | awk '{print ($1 >= 80) ? "brightgreen" : ($1 >= 50) ? "yellow" : "red"}')
-            curl -s "https://img.shields.io/badge/coverage-${PCT}%25-${COLOR}?${STYLE}" > badges/coverage.svg
-          else
-            curl -s "https://img.shields.io/badge/coverage-N%2FA-lightgrey?${STYLE}" > badges/coverage.svg
-          fi
-
-          curl -s "https://img.shields.io/badge/build-${{ steps.build.outputs.status }}-${{ steps.build.outputs.color }}?${STYLE}&logo=githubactions" > badges/build.svg
-          curl -s "https://img.shields.io/npm/v/@nanocollective/sentinel?${STYLE}&logo=npm" > badges/npm-version.svg
-          curl -s "https://img.shields.io/npm/dm/@nanocollective/sentinel?${STYLE}&logo=npm" > badges/npm-downloads-monthly.svg
-          curl -s "https://img.shields.io/npm/l/@nanocollective/sentinel?${STYLE}" > badges/npm-license.svg
-          curl -s "https://img.shields.io/github/repo-size/Nano-Collective/sentinel?${STYLE}&logo=github" > badges/repo-size.svg
-          curl -s "https://img.shields.io/github/stars/Nano-Collective/sentinel?${STYLE}&logo=github" > badges/stars.svg
-          curl -s "https://img.shields.io/github/forks/Nano-Collective/sentinel?${STYLE}&logo=github" > badges/forks.svg
-
-      - name: Commit and push badges
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add badges/
-          if ! git diff --cached --quiet; then
-            git commit -m "chore: update status badges [skip ci]" || echo "No changes"
-            git push
-          else
-            echo "No changes to commit"
-          fi
+  badges:
+    uses: Nano-Collective/.github/.github/workflows/update-badges.yml@main
+    with:
+      # This repo built before running tests, and its coverage run depends on it.
+      build-before-tests: true
+    secrets:
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
The machinery moves to [`Nano-Collective/.github`](https://github.com/Nano-Collective/.github/blob/main/.github/workflows/update-badges.yml); the schedule and the PAT stay here.

## Why

All seven package repos produced **the same eight badges** from files that had drifted to between **89 and 147 lines** — different action pinning, different step names, different quoting, one with an extra build step. Nothing about *"fetch a shields.io SVG and commit it"* is project-specific.

## What the shared version does that the copies did not

- **Pins every action by SHA.** Several repos pinned by mutable tag (`actions/checkout@v4`), which Semgrep flags as `github-actions-mutable-action-tag` — part of why the advisory scan sits permanently red on some repos. Measured on get-md: **10 findings → 7** after adopting this.
- **Derives the npm package name from `package.json`** and the slug from `github.repository`, instead of hardcoding both. Restating them per repo is how a copy ends up pointing at the wrong package after a rename.
- **Refuses to commit a badge that is not SVG.** shields.io returns an HTML error page for a bad package name, and committing that over a good badge is worse than leaving a stale one.

## Verified before this rollout

get-md adopted it first and was dispatched end to end: the workflow ran green, regenerated all eight badges, pushed the commit, and the resulting `coverage.svg` read **94.47%** with `npm-version.svg` at **v1.7.0** — both correct, and the version proves the package-name derivation works.
