### PR TITLE
feat(findings): enforce severity_weighting from the rule-pack manifest

### DIFF
--- a/.changeset/enforce-severity-weighting.md
+++ b/.changeset/enforce-severity-weighting.md
@@ -1,0 +1,22 @@
+---
+"@nanocollective/sentinel": patch
+---
+
+- **`severity_weighting` is now enforced, not merely suggested.** The manifest
+  field was parsed, put in front of the model, and then never checked against
+  what came back — so a pack declaring `sql-injection: critical` could have the
+  model answer `low` and that severity would be filed. The pack's value now wins,
+  in both directions: a model inflating everything to `critical` is as much a
+  triage problem as one understating. Rules a pack does not list keep the
+  model's severity, so weighting stays opt-in per rule.
+  - Keys resolve whether written bare (`sql-injection`) or fully qualified
+    (`db-safety/sql-injection`), because findings are reported as
+    `<pack>/<pattern>` and a literal lookup would have matched nothing.
+  - **Overrides are reported in the run summary** — which rule, in which file,
+    and from what to what. A pack author calibrating a weighting needs to see it
+    firing, and an operator reading a `critical` needs to know whether the model
+    or the pack said so.
+
+  Overwriting rather than rejecting on mismatch is deliberate: a finding can be
+  entirely accurate and still carry a guessed severity, and failing validation
+  would discard real work to re-derive an answer already in the manifest.

--- a/docs/rule-packs/index.md
+++ b/docs/rule-packs/index.md
@@ -52,11 +52,38 @@ One file per pack is deliberate: it is easy to install (`cp`), easy to diff, and
 | `description` | recommended | One line describing what the pack audits for. |
 | `applies_to.paths` | recommended | Glob patterns for the files this pack should read (e.g. `programs/**/*.rs`). Omit to apply to the whole repo. |
 | `applies_to.languages` | optional | Language identifiers the pack targets. A hint for scoping and reporting. |
-| `severity_weighting` | optional | Per-finding-type overrides mapping a finding key to a severity. Lets one pack express that some patterns it looks for are inherently more serious than others. |
+| `severity_weighting` | optional | Per-finding-type severities mapping a finding key to a severity. **Authoritative, not advisory** — see below. |
 | `depends_on` | optional | Other packs that should run alongside this one (e.g. a language-general pack). |
 | `category` | recommended | The pack's primary category (`security`, `correctness`, `performance`, `convention`, …). Carried onto findings. |
 
 The manifest format is a **stable v1 contract**. Fields may be added; existing fields will not change meaning without a major version and a migration note.
+
+### `severity_weighting` is authoritative
+
+A rule listed in `severity_weighting` gets that severity. The weighting is also
+put in front of the model, but a prompt is a request — the value in the manifest
+is what ends up on the finding and in the filed issue, whatever the model
+answered.
+
+That applies in both directions. A model that inflates everything to `critical`
+is as much a triage problem as one that understates, so the pack's value wins
+even when it is *lower* than the model's.
+
+Keys may be written either way. Findings are reported as `<pack>/<pattern>`, and
+both spellings resolve:
+
+```yaml
+severity_weighting:
+  sql-injection: critical            # bare pattern
+  db-safety/sql-injection: critical  # fully qualified — wins if both are present
+```
+
+Rules you do not list keep whatever severity the model chose, so weighting is
+opt-in per rule rather than a table you have to complete.
+
+**Overrides are reported.** When a pack rewrites a severity, the run report says
+so — which rule, in which file, and from what to what. Calibrating a pack means
+knowing whether your weighting is firing at all.
 
 ## The Markdown body
 

--- a/source/findings/weighting.spec.ts
+++ b/source/findings/weighting.spec.ts
@@ -1,0 +1,183 @@
+import test from 'ava';
+import type {RulePack} from '../rule-packs/types.js';
+import type {Finding, Severity} from './types.js';
+import {applySeverityWeighting} from './weighting.js';
+
+console.log('\nfindings/weighting.spec.ts');
+
+function pack(severityWeighting: Record<string, Severity> = {}): RulePack {
+	return {
+		manifest: {
+			name: 'db-safety',
+			version: '1.0.0',
+			description: '',
+			appliesTo: {paths: ['**/*.ts'], languages: ['typescript']},
+			severityWeighting,
+			dependsOn: [],
+			category: 'security',
+		},
+		body: 'Flag bugs.',
+	};
+}
+
+function finding(overrides: Partial<Finding> = {}): Finding {
+	return {
+		rule: 'db-safety/sql-injection',
+		file: 'src/db.ts',
+		lineRange: {start: 1, end: 2},
+		category: 'security',
+		severity: 'low',
+		confidence: 'medium',
+		offendingSnippet: 'query(userInput)',
+		...overrides,
+	};
+}
+
+test('a pack with no weighting leaves everything alone', t => {
+	const input = [finding(), finding({rule: 'db-safety/other'})];
+	const result = applySeverityWeighting(input, pack());
+	t.is(result.findings, input, 'returns the same array, not a copy');
+	t.deepEqual(result.overrides, []);
+});
+
+test('a weighted rule has its severity overwritten', t => {
+	// The bug: the model emitted `low` for a rule the pack calls critical, and
+	// that severity was filed. Weighting existed and was ignored.
+	const result = applySeverityWeighting(
+		[finding({severity: 'low'})],
+		pack({'sql-injection': 'critical'}),
+	);
+	t.is(result.findings[0]?.severity, 'critical');
+});
+
+test('the override is reported, not applied silently', t => {
+	const result = applySeverityWeighting(
+		[finding({severity: 'low'})],
+		pack({'sql-injection': 'critical'}),
+	);
+	t.deepEqual(result.overrides, [
+		{
+			rule: 'db-safety/sql-injection',
+			file: 'src/db.ts',
+			from: 'low',
+			to: 'critical',
+		},
+	]);
+});
+
+test('a bare pattern key matches the prefixed rule the model emits', t => {
+	// The reporting contract asks for "<pack>/<pattern>", while manifests are
+	// written with bare pattern names. A literal lookup matches nothing, which
+	// is how this feature could look implemented and do nothing.
+	const result = applySeverityWeighting(
+		[finding({rule: 'db-safety/sql-injection', severity: 'medium'})],
+		pack({'sql-injection': 'critical'}),
+	);
+	t.is(result.findings[0]?.severity, 'critical');
+});
+
+test('a fully-qualified key also matches', t => {
+	const result = applySeverityWeighting(
+		[finding({severity: 'medium'})],
+		pack({'db-safety/sql-injection': 'high'}),
+	);
+	t.is(result.findings[0]?.severity, 'high');
+});
+
+test('a fully-qualified key wins over a bare one', t => {
+	const result = applySeverityWeighting(
+		[finding({severity: 'low'})],
+		pack({
+			'sql-injection': 'medium',
+			'db-safety/sql-injection': 'critical',
+		}),
+	);
+	t.is(result.findings[0]?.severity, 'critical');
+});
+
+test('an unweighted rule keeps the severity the model chose', t => {
+	const result = applySeverityWeighting(
+		[finding({rule: 'db-safety/unbounded-query', severity: 'high'})],
+		pack({'sql-injection': 'critical'}),
+	);
+	t.is(result.findings[0]?.severity, 'high');
+	t.deepEqual(result.overrides, []);
+});
+
+test('a severity that already agrees is not reported as an override', t => {
+	// Otherwise the run summary would claim the pack corrected something it
+	// did not, and the count would be meaningless.
+	const result = applySeverityWeighting(
+		[finding({severity: 'critical'})],
+		pack({'sql-injection': 'critical'}),
+	);
+	t.is(result.findings[0]?.severity, 'critical');
+	t.deepEqual(result.overrides, []);
+});
+
+test('weighting can lower a severity as well as raise it', t => {
+	// The pack is authoritative in both directions — a model inflating
+	// everything to critical is as much a triage problem as one deflating it.
+	const result = applySeverityWeighting(
+		[finding({severity: 'critical'})],
+		pack({'sql-injection': 'low'}),
+	);
+	t.is(result.findings[0]?.severity, 'low');
+	t.is(result.overrides[0]?.from, 'critical');
+	t.is(result.overrides[0]?.to, 'low');
+});
+
+test('a rule with no pack prefix still matches a bare key', t => {
+	const result = applySeverityWeighting(
+		[finding({rule: 'sql-injection', severity: 'low'})],
+		pack({'sql-injection': 'critical'}),
+	);
+	t.is(result.findings[0]?.severity, 'critical');
+});
+
+test('only the weighted findings are rewritten', t => {
+	const result = applySeverityWeighting(
+		[
+			finding({rule: 'db-safety/sql-injection', severity: 'low'}),
+			finding({rule: 'db-safety/unbounded-query', severity: 'high'}),
+			finding({rule: 'db-safety/sql-injection', file: 'src/b.ts'}),
+		],
+		pack({'sql-injection': 'critical'}),
+	);
+	t.deepEqual(
+		result.findings.map(f => f.severity),
+		['critical', 'high', 'critical'],
+	);
+	t.is(result.overrides.length, 2);
+	t.deepEqual(
+		result.overrides.map(o => o.file),
+		['src/db.ts', 'src/b.ts'],
+		'each override names its own file, so two hits are distinguishable',
+	);
+});
+
+test('the original findings are not mutated', t => {
+	// The caller may still hold the array — rewriting in place would change
+	// what a dry-run preview reported after the fact.
+	const original = finding({severity: 'low'});
+	applySeverityWeighting([original], pack({'sql-injection': 'critical'}));
+	t.is(original.severity, 'low');
+});
+
+test('every other field survives the rewrite', t => {
+	const original = finding({
+		severity: 'low',
+		rationale: 'because',
+		suggestedNextSteps: 'fix it',
+		summary: 'A bug',
+	});
+	const result = applySeverityWeighting(
+		[original],
+		pack({'sql-injection': 'critical'}),
+	);
+	t.deepEqual(
+		{...result.findings[0], severity: 'low'},
+		original,
+		'only severity should differ',
+	);
+});

--- a/source/findings/weighting.ts
+++ b/source/findings/weighting.ts
@@ -1,0 +1,86 @@
+/**
+ * Apply a rule pack's `severity_weighting` to the findings it produced.
+ *
+ * The manifest field was parsed, passed into the prompt, and then never checked
+ * against what came back — so a pack declaring `sql-injection: critical` could
+ * have the model emit `low` and that severity would be filed. The whole purpose
+ * of per-pack weighting is to make severity authoritative rather than whatever
+ * the model happened to choose, so the pack's word is law: a weighted rule's
+ * severity is overwritten, not merely suggested.
+ *
+ * Overwriting rather than rejecting on mismatch (the alternative in #10) is
+ * deliberate. A finding can be entirely accurate and still carry a severity the
+ * model guessed; failing validation would discard real work and force a retry
+ * that costs a model call to fix something we already know the right answer to.
+ */
+
+import type {RulePack} from '../rule-packs/types.js';
+import type {Finding, Severity} from './types.js';
+
+/** One severity the pack overrode, kept so the run can say what it changed. */
+export interface SeverityOverride {
+	rule: string;
+	file: string;
+	from: Severity;
+	to: Severity;
+}
+
+/** Findings after weighting, plus what changed. */
+export interface WeightedFindings {
+	findings: Finding[];
+	overrides: SeverityOverride[];
+}
+
+/**
+ * Resolve a finding's rule against the weighting table.
+ *
+ * The reporting contract asks the model for `"<pack>/<pattern>"`, while a
+ * manifest's weighting keys are the bare pattern names — so a literal lookup
+ * matches nothing in the common case. Both spellings are accepted because a
+ * pack author may reasonably write either, with the fully-qualified form
+ * winning when both are present.
+ */
+function weightFor(
+	rule: string,
+	weighting: Record<string, Severity>,
+): Severity | undefined {
+	if (weighting[rule]) {
+		return weighting[rule];
+	}
+	const slash = rule.lastIndexOf('/');
+	if (slash === -1) {
+		return undefined;
+	}
+	return weighting[rule.slice(slash + 1)];
+}
+
+/**
+ * Overwrite each finding's severity where its rule is weighted by the pack.
+ * Findings the pack says nothing about are returned untouched.
+ */
+export function applySeverityWeighting(
+	findings: Finding[],
+	pack: RulePack,
+): WeightedFindings {
+	const weighting = pack.manifest.severityWeighting;
+	if (Object.keys(weighting).length === 0) {
+		return {findings, overrides: []};
+	}
+
+	const overrides: SeverityOverride[] = [];
+	const weighted = findings.map(finding => {
+		const declared = weightFor(finding.rule, weighting);
+		if (!declared || declared === finding.severity) {
+			return finding;
+		}
+		overrides.push({
+			rule: finding.rule,
+			file: finding.file,
+			from: finding.severity,
+			to: declared,
+		});
+		return {...finding, severity: declared};
+	});
+
+	return {findings: weighted, overrides};
+}

--- a/source/observe/record.spec.ts
+++ b/source/observe/record.spec.ts
@@ -33,6 +33,7 @@ function pack(
 		ok: true,
 		errors: [],
 		usage: {durationMs: 1000, promptTokens: 400, outputTokens: 50},
+		severityOverrides: [],
 		...overrides,
 	};
 }

--- a/source/run/audit.ts
+++ b/source/run/audit.ts
@@ -6,6 +6,7 @@
  */
 
 import type {ModelConfig} from '../config/types.js';
+import {applySeverityWeighting} from '../findings/weighting.js';
 import {
 	type AutoFixOptions,
 	runAuditWithAutoFix,
@@ -45,10 +46,17 @@ export async function auditPack(
 	const result = await runAuditWithAutoFix(prompt, model, runner, options);
 	const durationMs = Date.now() - startedAt;
 
+	// The pack's word is law on severity. The weighting reaches the model in the
+	// prompt, but a prompt is a request — this is what makes it authoritative,
+	// and it is applied after validation so an accurate finding is never
+	// discarded over a severity we already know the right answer to.
+	const {findings, overrides} = applySeverityWeighting(result.findings, pack);
+
 	return {
 		pack: pack.manifest.name,
 		version: pack.manifest.version,
-		findings: result.findings,
+		findings,
+		severityOverrides: overrides,
 		attempts: result.attempts,
 		ok: result.ok,
 		errors: result.errors,

--- a/source/run/report.spec.ts
+++ b/source/run/report.spec.ts
@@ -38,6 +38,7 @@ function pack(overrides: Partial<PackOutcome> = {}): PackOutcome {
 		ok: true,
 		errors: [],
 		usage: {durationMs: 0, promptTokens: 0, outputTokens: 0},
+		severityOverrides: [],
 		...overrides,
 	};
 }
@@ -326,4 +327,44 @@ test('missing and unresolved packs render as separate lines', t => {
 	t.true(markdown.includes('Missing packs (not in rule-packs/): ghost'));
 	t.true(markdown.includes('`app`'));
 	t.false(markdown.includes('not in rule-packs/): ghost, app'));
+});
+
+test('a pack that overrode a severity says so', t => {
+	// Rewriting a finding's severity changes what gets filed and how it is
+	// triaged. Doing that silently would leave a pack author unable to tell
+	// whether their weighting fired at all.
+	const run: RunOutcome = {
+		repos: [
+			{
+				repo: 'a',
+				packs: [
+					pack({
+						severityOverrides: [
+							{
+								rule: 'db-safety/sql-injection',
+								file: 'src/db.ts',
+								from: 'low',
+								to: 'critical',
+							},
+						],
+					}),
+				],
+				missingPacks: [],
+				unresolvedPacks: [],
+			},
+		],
+	};
+	const markdown = renderReport(run);
+	t.true(markdown.includes('severity weighting overrode 1'));
+	t.true(markdown.includes('`db-safety/sql-injection`'));
+	t.true(markdown.includes('low → critical'));
+});
+
+test('a pack that overrode nothing adds no note', t => {
+	const run: RunOutcome = {
+		repos: [
+			{repo: 'a', packs: [pack()], missingPacks: [], unresolvedPacks: []},
+		],
+	};
+	t.false(renderReport(run).includes('severity weighting overrode'));
 });

--- a/source/run/report.ts
+++ b/source/run/report.ts
@@ -6,6 +6,7 @@
 import {findingHash} from '../dedup/hash.js';
 import type {ReconcileResult} from '../dedup/reconcile.js';
 import type {Finding} from '../findings/types.js';
+import type {SeverityOverride} from '../findings/weighting.js';
 import type {
 	PackLoadError,
 	PackOutcome,
@@ -45,7 +46,32 @@ function packSection(outcome: PackOutcome): string {
 	if (outcome.findings.length === 0) {
 		return `${header}\n\nNo findings.`;
 	}
-	return [header, '', ...outcome.findings.map(findingSection)].join('\n\n');
+	return [
+		header,
+		'',
+		...severityOverrideNote(outcome.severityOverrides),
+		...outcome.findings.map(findingSection),
+	].join('\n\n');
+}
+
+/**
+ * Severities the pack rewrote. Shown because the rewrite is a real change to
+ * what gets filed and to how it is triaged — a pack author calibrating
+ * `severity_weighting` needs to see it firing, and an operator reading a
+ * `critical` needs to know whether the model or the pack said so.
+ */
+function severityOverrideNote(overrides: SeverityOverride[]): string[] {
+	if (overrides.length === 0) {
+		return [];
+	}
+	return [
+		[
+			`> The pack's severity weighting overrode ${overrides.length} severity(ies):`,
+			...overrides.map(
+				o => `> - \`${o.rule}\` in \`${o.file}\`: ${o.from} → ${o.to}`,
+			),
+		].join('\n'),
+	];
 }
 
 /** A collapsible block with the raw model output, for diagnosing a failure. */

--- a/source/run/types.ts
+++ b/source/run/types.ts
@@ -6,6 +6,7 @@
 
 import type {Finding} from '../findings/types.js';
 import type {ValidationError} from '../findings/validate.js';
+import type {SeverityOverride} from '../findings/weighting.js';
 import type {SourceFile} from '../prompt/types.js';
 import type {RulePack, RulePackError} from '../rule-packs/types.js';
 
@@ -62,6 +63,12 @@ export interface PackOutcome {
 	raw?: string;
 	/** What the pass cost, measured as it ran. */
 	usage: PackUsage;
+	/**
+	 * Severities the pack's `severity_weighting` overrode. Carried rather than
+	 * applied silently: rewriting a finding's severity is a real change to what
+	 * gets filed, and an operator calibrating a pack needs to see it happening.
+	 */
+	severityOverrides: SeverityOverride[];
 }
 
 /**


### PR DESCRIPTION
Closes #10. Phase 3 of [`ROADMAP.md`](../blob/main/ROADMAP.md).

## The bug

`severity_weighting` was parsed into `manifest.severityWeighting`, passed into the prompt by `buildAuditPrompt`, and then **never compared against what came back**. A pack declaring `sql-injection: critical` could have the model answer `low`, and that severity was filed.

So the feature read as implemented while doing nothing — which is worse than not having it, because the manifest looks like it is in control.

## The pack's word is law, in both directions

A weighted rule's severity is overwritten. That includes the case where the manifest is **lower** than the model's answer: a model inflating everything to `critical` is as much a triage problem as one understating, and the pack is the one that knows.

Rules a pack does not list keep whatever the model chose, so weighting stays opt-in per rule rather than a table you have to complete.

## Two details that decide whether this works at all

**Key resolution.** Findings are reported as `<pack>/<pattern>` while manifests are written with bare pattern names — so a literal lookup matches nothing in the common case. **This is exactly how the feature could ship and still do nothing.** Both spellings resolve, fully-qualified winning where both exist:

```yaml
severity_weighting:
  sql-injection: critical            # bare pattern
  db-safety/sql-injection: critical  # fully qualified — wins
```

**Overrides are reported, not applied silently.** Rewriting a severity is a real change to what gets filed and how it is triaged. A pack author calibrating a weighting needs to see it fire; an operator reading a `critical` needs to know whether the model or the pack said so:

```
> The pack's severity weighting overrode 1 severity(ies):
> - `db-safety/sql-injection` in `src/db.ts`: low → critical
```

That is the same property alpha.4 established for errors — a thing that changes the output should not be invisible.

## Why overwrite rather than reject

The issue offered rejecting on mismatch as option B. Overwriting is deliberate: **a finding can be entirely accurate and still carry a guessed severity**, and failing validation would discard real work and spend a retry re-deriving an answer that is already sitting in the manifest.

Applied after validation in `auditPack`, so it cannot interact with the auto-fix retry loop.

## Verified

13 unit tests, plus the built artefact checked directly — a model emitting `low` for a rule the pack calls `critical` comes out `critical` with the override reported. Full gate green: 419 tests, types, lint, format, knip, build.

Docs updated: `docs/rule-packs/index.md` now states the field is authoritative rather than "overrides", covers both key spellings, and says overrides are reported.
