### PR TITLE
ci: allow the Version PR workflow to be dispatched manually

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -9,6 +9,13 @@ name: Prepare Release (Version PR)
 on:
   push:
     branches: [main]
+  # Manual re-trigger. A push is normally what rebuilds the Version PR, but if
+  # this workflow fails for a reason outside the repository — a broken action,
+  # a token, an outage — the only way back is another commit to main, and an
+  # empty commit is a poor way to retry a release. Re-running the failed run
+  # does not help: a run pins the shared workflow at the commit it resolved
+  # when it started, so a re-run replays the same broken version.
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Adds `workflow_dispatch` to the Version PR caller, and doubles as the fresh run that verifies [.github#3](https://github.com/Nano-Collective/.github/pull/3).

## Why

Sentinel's Version PR job has been failing since #25 merged, so the `severity_weighting` changeset on `main` has no Version PR. The cause was in the shared workflow — `changesets/action@v1` bundles a reader that still understands the Changesets **v1** folder format and chokes on the `.changeset/pre/` archive that Changesets v3 creates in prerelease mode. That is fixed in `.github#3`.

Fixing it surfaced a second, smaller gap, which is what this PR closes.

## Re-running a failed run does not pick up a fixed shared workflow

I tried exactly that first. **A run pins the shared workflow at the commit it resolved when it started**, so the re-run downloaded the same broken `changesets/action@e0145ed` and failed identically. Verified in the logs, not assumed.

That leaves a push to `main` as the only way to retry — and when the thing that broke is *outside* the repository (a bad action release, a token, an outage), an empty commit is a poor way to retry a release. `workflow_dispatch` is the missing escape hatch.

## Note on scope

Deliberately just this repo. If it proves useful the same three lines belong in every caller, and a `templates/release-prepare.caller.yml` in `.github` alongside the other caller templates — worth doing once, not seven times speculatively.
