### PR TITLE
feat(dedup): auto-resolution only counts runs that actually looked

### DIFF
--- a/.changeset/scope-aware-reconciliation.md
+++ b/.changeset/scope-aware-reconciliation.md
@@ -1,0 +1,30 @@
+---
+"@nanocollective/sentinel": patch
+---
+
+- **Auto-resolution now only counts runs that actually looked.** Reconciliation
+  could not distinguish *the finding is gone* from *the file was not read* —
+  both arrive at the planner as an absent finding, and both bumped the miss
+  counter until the issue was closed as fixed. That is harmless while every run
+  reads every file and catastrophic the moment one does not: it is the shape of
+  an audit tool reporting a vulnerability as fixed because it stopped looking.
+
+  A run now carries the scope it read, and an open issue whose file was not read
+  is **held** — neither refreshed nor aged, its miss counter left exactly where
+  it was. Holding is recoverable; auto-closing a real finding is not.
+
+  - **Scope is per rule pack, not per repository.** Packs do not read the same
+    files, so a repo-wide scope would call a file "scanned" for a pack that
+    never opened it and reintroduce the bug for anything running more than one
+    pack.
+  - Filed issues carry `pack` and `path` markers. The file was previously only
+    prose in the body, and the pack was not recorded at all — parsing either
+    back out would have broken the first time the template changed.
+  - **Held issues are reported**, separately from aged ones, in the run summary,
+    the dry-run preview, the run record and the dashboard. `aged` means Sentinel
+    looked and did not find; `held` means it did not look, and collapsing the
+    two would hide the distinction this exists to draw.
+
+  Behaviour is unchanged today: every run still reads every file, so every scope
+  is complete and nothing is ever held. This lands first so that incremental
+  scanning cannot be added without it.

--- a/docs/findings/index.md
+++ b/docs/findings/index.md
@@ -62,6 +62,20 @@ The **line range is deliberately excluded** from the hash. LLMs report slightly 
 
 A later run that produces the same finding **updates the existing issue's last-seen timestamp** instead of opening a duplicate. A finding that stops appearing across N consecutive runs is marked resolved automatically.
 
+### Auto-resolution only counts runs that looked
+
+"The finding is gone" and "the file was not read" arrive at the planner looking identical — in both cases the finding is simply absent. They mean opposite things, and treating the second as the first is how an audit tool ends up reporting a vulnerability as fixed because it stopped looking.
+
+So Sentinel records what each run actually read, and an open issue whose file was not read this run is **held**: neither refreshed nor aged, its miss counter left exactly where it was. Holding is recoverable — the issue stays open until a run reads the file again — where auto-closing is not.
+
+The scope is tracked **per rule pack**, because packs do not read the same files. If one pack skipped `src/db.ts` while another read it, an issue the first pack filed against that file was not re-examined, even though something looked at it.
+
+Held issues are counted separately from aged ones in the run summary, the run record and the dashboard. `aged` means Sentinel looked and did not find; `held` means it did not look. Collapsing them would hide the distinction this exists to draw.
+
+Today every run reads every file, so `held` is always zero. It becomes meaningful with [incremental scanning](https://github.com/Nano-Collective/sentinel/issues/17), which is what makes skipping files safe rather than quietly destructive.
+
+Issues filed before Sentinel recorded this carry no file marker. They keep exactly their old behaviour while runs read everything, and they are marked the next time their finding recurs — which happens before any file is skipped, because the first run in a repository always reads everything.
+
 ## Suppression
 
 False positives are inherent to any LLM-driven audit. Sentinel does not try to eliminate them before release — it makes them cheap to dismiss, the same way a reviewer marks a comment resolved. There are three layers, in increasing specificity:
@@ -78,10 +92,10 @@ Reach for the least specific layer that solves the problem. A one-off wrong find
 Every layer is counted in the per-repo run summary, so you can see which one is doing the work:
 
 ```
-myorg/myrepo: filed 3, touched 5, aged 2, suppressed 1, suppressed-by-override 0, resolved 0
+myorg/myrepo: filed 3, touched 5, aged 2, held 0, suppressed 1, suppressed-by-override 0, resolved 0
 ```
 
-`touched` is layer 1 — an existing issue matched instead of a duplicate being filed. `suppressed` is layer 2, findings silenced by an issue carrying one of the `sentinel:false-positive` / `sentinel:wontfix` / `sentinel:accepted` labels. The label is what counts, not the close — an issue left open with a suppression label on it suppresses too, so a `wontfix` you never closed still shows up here. `suppressed-by-override` is layer 3, findings the audited repo's own `sentinel.yaml` removed. `aged` is the number of open issues that moved one run closer to auto-resolution. Counters print even when zero — a zero is the signal that a layer is not firing, though read it alongside the errors printed underneath: an issue update that failed is reported as an error and is not counted here, so a run with errors can under-report. The same numbers are written to the [run record](../workflow/index.md#observability-and-run-history) and shown in the dashboard, so a scheduled run stays triageable after the fact.
+`touched` is layer 1 — an existing issue matched instead of a duplicate being filed. `suppressed` is layer 2, findings silenced by an issue carrying one of the `sentinel:false-positive` / `sentinel:wontfix` / `sentinel:accepted` labels. The label is what counts, not the close — an issue left open with a suppression label on it suppresses too, so a `wontfix` you never closed still shows up here. `suppressed-by-override` is layer 3, findings the audited repo's own `sentinel.yaml` removed. `aged` is the number of open issues that moved one run closer to auto-resolution, and `held` the number left untouched because this run did not read their file. Counters print even when zero — a zero is the signal that a layer is not firing, though read it alongside the errors printed underneath: an issue update that failed is reported as an error and is not counted here, so a run with errors can under-report. The same numbers are written to the [run record](../workflow/index.md#observability-and-run-history) and shown in the dashboard, so a scheduled run stays triageable after the fact.
 
 ## Honest about false positives
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,4 +22,4 @@ onlyBuiltDependencies:
   - '@biomejs/biome'
   - esbuild
 
-auditConfig: {}
+auditConfig: { ignoreGhsas: null }

--- a/source/dedup/plan.spec.ts
+++ b/source/dedup/plan.spec.ts
@@ -2,8 +2,9 @@ import test from 'ava';
 import type {Finding} from '../findings/types.js';
 import type {ExistingIssue} from '../issues/types.js';
 import {findingHash} from './hash.js';
-import {upsertMarker} from './markers.js';
+import {readMisses, upsertMarker} from './markers.js';
 import {planReconciliation} from './plan.js';
+import {fullScope} from './scope.js';
 
 console.log('\ndedup/plan.spec.ts');
 
@@ -151,4 +152,112 @@ test('ignores existing issues with no hash marker', t => {
 	);
 	t.deepEqual(plan.toCreate, [f]);
 	t.is(plan.toIncrementMiss.length, 0);
+});
+
+/** An issue carrying the hash plus the scope markers a current run writes. */
+function markedIssueFor(
+	f: Finding,
+	pack: string,
+	overrides: Partial<ExistingIssue> = {},
+): ExistingIssue {
+	const base = issueFor(f, overrides);
+	return {
+		...base,
+		body: upsertMarker(upsertMarker(base.body, 'pack', pack), 'path', f.file),
+	};
+}
+
+test('with no scope, an absent finding ages out exactly as before', t => {
+	const gone = finding('gone.rs');
+	const plan = planReconciliation([], [markedIssueFor(gone, 'p')]);
+	t.is(plan.toIncrementMiss.length, 1);
+	t.is(plan.held.length, 0);
+});
+
+test('a full scope changes nothing about ageing', t => {
+	const gone = finding('gone.rs');
+	const plan = planReconciliation([], [markedIssueFor(gone, 'p')], {
+		scope: fullScope(['p']),
+	});
+	t.is(plan.toIncrementMiss.length, 1);
+	t.is(plan.held.length, 0);
+});
+
+test('an issue whose file was not read is held, not aged', t => {
+	const gone = finding('unscanned.rs');
+	const plan = planReconciliation([], [markedIssueFor(gone, 'p')], {
+		scope: {
+			scannedByPack: new Map([['p', new Set(['other.rs'])]]),
+			fullPacks: new Set(),
+		},
+	});
+	t.is(plan.held.length, 1, 'held');
+	t.is(plan.toIncrementMiss.length, 0, 'not aged');
+	t.is(plan.toResolve.length, 0, 'not resolved');
+});
+
+test('a held issue is not resolved even when already at the threshold', t => {
+	// The dangerous case: an issue one miss away from being auto-closed, whose
+	// file this run did not read. Ageing it here closes a real finding.
+	const gone = finding('unscanned.rs');
+	const issue = markedIssueFor(gone, 'p');
+	const plan = planReconciliation(
+		[],
+		[{...issue, body: upsertMarker(issue.body, 'misses', '2')}],
+		{
+			resolveAfterMisses: 3,
+			scope: {
+				scannedByPack: new Map([['p', new Set(['other.rs'])]]),
+				fullPacks: new Set(),
+			},
+		},
+	);
+	t.is(plan.toResolve.length, 0);
+	t.is(plan.held.length, 1);
+});
+
+test('an issue whose file WAS read still ages out under a partial scope', t => {
+	// Holding must be narrow. A finding that genuinely stopped recurring in a
+	// file the run did read has to keep closing itself, or auto-resolution is
+	// dead the moment incremental scanning is switched on.
+	const gone = finding('scanned.rs');
+	const plan = planReconciliation([], [markedIssueFor(gone, 'p')], {
+		scope: {
+			scannedByPack: new Map([['p', new Set(['scanned.rs'])]]),
+			fullPacks: new Set(),
+		},
+	});
+	t.is(plan.toIncrementMiss.length, 1);
+	t.is(plan.held.length, 0);
+});
+
+test('holding survives repeated runs — the acceptance property', t => {
+	// Reconciliation across several incremental runs in which the file is never
+	// read. Without the scope the miss counter reaches the threshold and the
+	// issue is closed; with it, the counter never moves at all.
+	const gone = finding('unscanned.rs');
+	let issue = markedIssueFor(gone, 'p');
+	const scope = {
+		scannedByPack: new Map([['p', new Set(['other.rs'])]]),
+		fullPacks: new Set<string>(),
+	};
+
+	for (let run = 0; run < 5; run++) {
+		const plan = planReconciliation([], [issue], {
+			resolveAfterMisses: 3,
+			scope,
+		});
+		t.is(plan.toResolve.length, 0, `run ${run}: not resolved`);
+		t.is(plan.held.length, 1, `run ${run}: held`);
+		// A held issue is not rewritten, so its body carries into the next run
+		// unchanged — including its miss counter.
+		for (const {issue: aged, misses} of plan.toIncrementMiss) {
+			issue = {
+				...aged,
+				body: upsertMarker(aged.body, 'misses', String(misses)),
+			};
+		}
+	}
+
+	t.is(readMisses(issue.body), 0, 'the miss counter never moved');
 });

--- a/source/dedup/plan.ts
+++ b/source/dedup/plan.ts
@@ -2,15 +2,16 @@
  * The dedup planner. Given this run's findings and the issues that already
  * exist on the target repo, decide what to do with each: file a new issue,
  * touch (reset) an existing one, suppress it (a maintainer closed it with a
- * suppression label), or resolve a stale issue whose finding has been absent
- * for enough consecutive runs. Pure and fully tested; the executor
- * (reconcile.ts) applies the plan.
+ * suppression label), hold one whose file this run did not read, or resolve a
+ * stale issue whose finding has been absent for enough consecutive runs. Pure
+ * and fully tested; the executor (reconcile.ts) applies the plan.
  */
 
 import type {Finding} from '../findings/types.js';
 import type {ExistingIssue} from '../issues/types.js';
 import {findingHash} from './hash.js';
 import {readMarker, readMisses} from './markers.js';
+import {issueWasScanned, type ScanScope} from './scope.js';
 
 /** Closing an issue with one of these labels means "do not refile". */
 export const SUPPRESSION_LABELS = [
@@ -23,6 +24,12 @@ export const SUPPRESSION_LABELS = [
 export interface ReconcileOptions {
 	/** Consecutive absent runs before an open issue is auto-resolved. Min 1. */
 	resolveAfterMisses?: number;
+	/**
+	 * What this run actually read. Omit when every file was read — the planner
+	 * then behaves exactly as it did before scope existed. Supplying a partial
+	 * scope is what stops an unscanned finding being mistaken for a fixed one.
+	 */
+	scope?: ScanScope;
 }
 
 /** An open issue matched by a finding this run: reset its miss counter. */
@@ -49,6 +56,14 @@ export interface ReconcilePlan {
 	toResolve: ExistingIssue[];
 	/** Open issues absent this run but below the resolve threshold. */
 	toIncrementMiss: MissOp[];
+	/**
+	 * Open issues whose file this run did not read. Absent from the findings, but
+	 * that absence is not evidence of anything — so they are left untouched, with
+	 * their miss counter exactly where it was. Reported rather than silent: "held,
+	 * not scanned" and "still open" are different states and an operator needs to
+	 * be able to tell them apart.
+	 */
+	held: ExistingIssue[];
 }
 
 function hasSuppressionLabel(issue: ExistingIssue): boolean {
@@ -97,6 +112,7 @@ export function planReconciliation(
 		suppressed: [],
 		toResolve: [],
 		toIncrementMiss: [],
+		held: [],
 	};
 
 	for (const [hash, finding] of findingByHash) {
@@ -112,9 +128,20 @@ export function planReconciliation(
 		}
 	}
 
-	// Open issues whose finding did not recur this run: age them out.
+	// Open issues whose finding did not recur this run: age them out — but only
+	// where "did not recur" is something this run is in a position to claim.
 	for (const [hash, issue] of openByHash) {
 		if (findingByHash.has(hash)) {
+			continue;
+		}
+		if (
+			!issueWasScanned(
+				options.scope,
+				readMarker(issue.body, 'pack'),
+				readMarker(issue.body, 'path'),
+			)
+		) {
+			plan.held.push(issue);
 			continue;
 		}
 		const misses = readMisses(issue.body) + 1;

--- a/source/dedup/reconcile.spec.ts
+++ b/source/dedup/reconcile.spec.ts
@@ -317,3 +317,77 @@ test('no label failures leaves the error list clean', async t => {
 	);
 	t.deepEqual(result.errors, []);
 });
+
+test('a filed issue carries the path marker', async t => {
+	const {client, created} = fakeClient();
+	const f = finding('src/db.rs');
+	await reconcileFindings([f], config(), client, CTX, NOW);
+	t.is(readMarker(created[0]?.body ?? '', 'path'), 'src/db.rs');
+});
+
+test('a filed issue carries the pack marker when the pack is known', async t => {
+	const {client, created} = fakeClient();
+	const f = finding('src/db.rs');
+	await reconcileFindings([f], config(), client, CTX, NOW, {
+		packOfFinding: new Map([[f, 'db-safety']]),
+	});
+	t.is(readMarker(created[0]?.body ?? '', 'pack'), 'db-safety');
+});
+
+test('an unattributable finding files without a pack marker', async t => {
+	// Safe direction: no marker means a later partial run holds the issue rather
+	// than ageing it out on the strength of a scan it cannot vouch for.
+	const {client, created} = fakeClient();
+	await reconcileFindings([finding('a.rs')], config(), client, CTX, NOW, {
+		packOfFinding: new Map(),
+	});
+	t.is(readMarker(created[0]?.body ?? '', 'pack'), null);
+});
+
+test('touching an issue backfills the scope markers', async t => {
+	// This is the migration. Issues filed before the markers existed get them
+	// the next time their finding recurs — and because the first run after an
+	// upgrade reads everything, that happens before any file is ever skipped.
+	const f = finding('src/db.rs');
+	const legacy = openIssueFor(f, 7);
+	t.is(readMarker(legacy.body, 'path'), null, 'starts unmarked');
+
+	const {client, updated} = fakeClient([legacy]);
+	await reconcileFindings([f], config(), client, CTX, NOW, {
+		packOfFinding: new Map([[f, 'db-safety']]),
+	});
+
+	t.is(updated.length, 1);
+	t.is(readMarker(updated[0]?.body ?? '', 'path'), 'src/db.rs');
+	t.is(readMarker(updated[0]?.body ?? '', 'pack'), 'db-safety');
+	t.is(readMisses(updated[0]?.body ?? ''), 0, 'still resets the counter');
+});
+
+test('a held issue is neither updated nor closed', async t => {
+	const gone = finding('unscanned.rs');
+	let body = upsertMarker('body', 'hash', findingHash(gone));
+	body = upsertMarker(upsertMarker(body, 'pack', 'p'), 'path', 'unscanned.rs');
+	body = upsertMarker(body, 'misses', '2');
+	const issue: ExistingIssue = {
+		number: 9,
+		url: 'u',
+		state: 'open',
+		labels: ['sentinel'],
+		body,
+	};
+
+	const {client, updated, closed} = fakeClient([issue]);
+	const result = await reconcileFindings([], config(), client, CTX, NOW, {
+		resolveAfterMisses: 3,
+		scope: {
+			scannedByPack: new Map([['p', new Set(['other.rs'])]]),
+			fullPacks: new Set(),
+		},
+	});
+
+	t.is(result.held, 1);
+	t.is(result.incremented, 0);
+	t.is(result.resolved, 0);
+	t.deepEqual(updated, [], 'the body is left exactly as it was');
+	t.deepEqual(closed, [], 'and nothing is closed');
+});

--- a/source/dedup/reconcile.ts
+++ b/source/dedup/reconcile.ts
@@ -8,7 +8,11 @@
 
 import type {RepoOverride, SentinelConfig} from '../config/types.js';
 import {type Finding, meetsSeverityThreshold} from '../findings/types.js';
-import {buildIssueContent, targetRepoFor} from '../issues/file.js';
+import {
+	buildIssueContent,
+	targetRepoFor,
+	withScopeMarkers,
+} from '../issues/file.js';
 import type {
 	CreatedIssue,
 	FilingContext,
@@ -22,6 +26,24 @@ import {
 	SUPPRESSION_LABELS,
 } from './plan.js';
 
+/**
+ * Options for the executor. Extends the planner's with the one thing only the
+ * executor needs: which pack produced each finding, so the issues it files
+ * carry the marker a later partial run reads back.
+ */
+export interface ReconcileExecOptions extends ReconcileOptions {
+	/**
+	 * The pack each finding came from, keyed by the finding object itself.
+	 *
+	 * Identity, not value: the findings handed to this function are the same
+	 * objects the run collected from each pack outcome (the override and
+	 * threshold steps filter, they do not copy). A finding missing from the map
+	 * simply files without a `pack` marker, which is the safe direction — an
+	 * unattributable issue is held on a partial run rather than aged out.
+	 */
+	packOfFinding?: ReadonlyMap<Finding, string>;
+}
+
 /** A summary of what one reconcile run did. */
 export interface ReconcileResult {
 	targetRepo: string;
@@ -29,6 +51,13 @@ export interface ReconcileResult {
 	touched: number;
 	incremented: number;
 	resolved: number;
+	/**
+	 * Open issues left alone because this run did not read their file. Counted
+	 * separately from `incremented` on purpose: an aged issue is one Sentinel
+	 * looked for and did not find, a held issue is one it never looked for, and
+	 * collapsing them would hide exactly the distinction this exists to make.
+	 */
+	held: number;
 	/** Findings suppressed by a label-closed issue (dedup layer). */
 	suppressed: number;
 	/** Findings removed by the per-repo override's suppress rules. */
@@ -66,7 +95,7 @@ export async function reconcileFindings(
 	client: ReconcileClient,
 	context: FilingContext,
 	now: string,
-	options: ReconcileOptions = {},
+	options: ReconcileExecOptions = {},
 	override?: RepoOverride,
 ): Promise<ReconcileResult> {
 	const targetRepo = targetRepoFor(config, context);
@@ -105,7 +134,10 @@ export async function reconcileFindings(
 
 	const created: CreatedIssue[] = [];
 	for (const finding of plan.toCreate) {
-		const content = buildIssueContent(finding, config, context);
+		const content = buildIssueContent(finding, config, {
+			...context,
+			pack: options.packOfFinding?.get(finding) ?? context.pack,
+		});
 		try {
 			created.push(
 				await client.createIssue({
@@ -122,12 +154,20 @@ export async function reconcileFindings(
 	}
 
 	let touched = 0;
-	for (const {issue} of plan.toTouch) {
+	for (const {issue, finding} of plan.toTouch) {
 		await tolerate(errors, `touch #${issue.number}`, async () => {
+			// Backfill the scope markers while we are already rewriting the body.
+			// This is what migrates issues filed before the markers existed: the
+			// first run after an upgrade reads every file, so every issue whose
+			// finding still recurs is touched here and is marked before any later
+			// run is in a position to skip anything.
 			await client.updateIssue({
 				repo: targetRepo,
 				number: issue.number,
-				body: trackedBody(issue.body, now),
+				body: withScopeMarkers(trackedBody(issue.body, now), finding, {
+					...context,
+					pack: options.packOfFinding?.get(finding) ?? context.pack,
+				}),
 			});
 			touched++;
 		});
@@ -165,6 +205,7 @@ export async function reconcileFindings(
 		touched,
 		incremented,
 		resolved,
+		held: plan.held.length,
 		suppressed: plan.suppressed.length,
 		suppressedByOverride: overrideSuppressed.length,
 		errors,

--- a/source/dedup/scope.spec.ts
+++ b/source/dedup/scope.spec.ts
@@ -1,0 +1,94 @@
+import test from 'ava';
+import {
+	fullScope,
+	isCompleteScope,
+	issueWasScanned,
+	type ScanScope,
+} from './scope.js';
+
+console.log('\ndedup/scope.spec.ts');
+
+/** A scope in which `pack` read exactly `paths` and nothing else. */
+function partial(
+	pack: string,
+	paths: string[],
+	full: string[] = [],
+): ScanScope {
+	return {
+		scannedByPack: new Map([[pack, new Set(paths)]]),
+		fullPacks: new Set(full),
+	};
+}
+
+test('a full scope is complete', t => {
+	t.true(isCompleteScope(fullScope(['a', 'b'])));
+});
+
+test('a scope with any reduced pack is not complete', t => {
+	t.false(isCompleteScope(partial('a', ['x.ts'])));
+});
+
+test('no scope at all means everything was scanned', t => {
+	// The pre-incremental caller passes nothing, and must keep its behaviour.
+	t.true(issueWasScanned(undefined, 'a', 'x.ts'));
+	t.true(issueWasScanned(undefined, null, null));
+});
+
+test('a complete scope means everything was scanned', t => {
+	t.true(issueWasScanned(fullScope(['a']), 'a', 'x.ts'));
+	t.true(issueWasScanned(fullScope(['a']), 'a', 'never-heard-of-it.ts'));
+});
+
+test('a file the pack read this run counts as scanned', t => {
+	t.true(issueWasScanned(partial('a', ['x.ts', 'y.ts']), 'a', 'x.ts'));
+});
+
+test('a file the pack skipped is NOT scanned — the whole point', t => {
+	// This is the bug the module exists to prevent: without it, an unscanned
+	// file's finding is absent from the run, gets its miss counter bumped, and
+	// after `resolveAfterMisses` runs the issue is closed as fixed.
+	t.false(issueWasScanned(partial('a', ['x.ts']), 'a', 'untouched.ts'));
+});
+
+test('scope is per pack, not per repository', t => {
+	// Pack `b` read the file; pack `a` did not. An issue `a` filed against it
+	// was not re-examined, even though something looked at the file. Collapsing
+	// the two packs would reintroduce the bug for any multi-pack repo.
+	const scope: ScanScope = {
+		scannedByPack: new Map([
+			['a', new Set(['other.ts'])],
+			['b', new Set(['shared.ts'])],
+		]),
+		fullPacks: new Set(),
+	};
+	t.false(issueWasScanned(scope, 'a', 'shared.ts'));
+	t.true(issueWasScanned(scope, 'b', 'shared.ts'));
+});
+
+test('a pack that read everything covers its files even when another was partial', t => {
+	const scope = partial('a', ['x.ts'], ['b']);
+	t.true(issueWasScanned(scope, 'b', 'anything.ts'));
+	t.false(issueWasScanned(scope, 'a', 'anything.ts'));
+});
+
+test('a pack that did not run at all ages out as it always has', t => {
+	// The target stopped naming the pack, or its depends_on chain broke. That is
+	// not an incremental skip, and holding those issues forever would mean a
+	// removed pack's findings could never close.
+	t.true(issueWasScanned(partial('a', ['x.ts']), 'removed-pack', 'x.ts'));
+});
+
+test('an unmarked issue is scanned on a complete run', t => {
+	// Issues filed before the markers existed keep exactly today's behaviour for
+	// as long as runs read everything, which is what makes the upgrade a no-op.
+	t.true(issueWasScanned(fullScope(['a']), null, null));
+});
+
+test('an unmarked issue is HELD on a partial run', t => {
+	// Deliberately the opposite of the complete-run case. An issue that cannot
+	// be attributed to a file is one we cannot prove we looked at, and holding
+	// is recoverable where closing is not.
+	t.false(issueWasScanned(partial('a', ['x.ts']), null, null));
+	t.false(issueWasScanned(partial('a', ['x.ts']), 'a', null));
+	t.false(issueWasScanned(partial('a', ['x.ts']), null, 'x.ts'));
+});

--- a/source/dedup/scope.ts
+++ b/source/dedup/scope.ts
@@ -1,0 +1,89 @@
+/**
+ * What a run actually looked at.
+ *
+ * Reconciliation ages an open issue out when its finding does not recur, and
+ * auto-resolves it after enough consecutive misses. That is only sound while
+ * every run reads every file: "the finding did not recur" and "the file was
+ * not read" are indistinguishable from the planner's side, and they mean
+ * opposite things. Absent this module, skipping unchanged files would close
+ * real, unfixed findings after `resolveAfterMisses` runs — the tool reporting a
+ * vulnerability as fixed because it stopped looking.
+ *
+ * So the scanned scope travels with the findings. An open issue whose file was
+ * not read this run is *held*: neither refreshed nor missed, its counter left
+ * exactly where it was.
+ *
+ * Scope is tracked per **pack**, not per repository, because packs do not read
+ * the same files. If pack A skipped `src/db.ts` while pack B read it, an issue
+ * A filed against `src/db.ts` was not re-examined even though something looked
+ * at the file. Collapsing the two would reintroduce the bug for any repo
+ * running more than one pack.
+ */
+
+/** The files one run read, per pack. */
+export interface ScanScope {
+	/**
+	 * Pack name → the paths that pack audited this run. Only packs that ran with
+	 * a *reduced* file set appear here; a pack that read everything it applies to
+	 * belongs in {@link fullPacks}, which needs no path set.
+	 */
+	scannedByPack: Map<string, Set<string>>;
+	/** Packs that read everything they apply to, so nothing of theirs was missed. */
+	fullPacks: Set<string>;
+}
+
+/** A scope in which every named pack read everything it applies to. */
+export function fullScope(packs: Iterable<string>): ScanScope {
+	return {scannedByPack: new Map(), fullPacks: new Set(packs)};
+}
+
+/**
+ * True when no pack ran with a reduced file set, so this run is equivalent to
+ * the pre-incremental behaviour and nothing can be held.
+ */
+export function isCompleteScope(scope: ScanScope): boolean {
+	return scope.scannedByPack.size === 0;
+}
+
+/**
+ * Whether an open issue's subject was actually read this run, and therefore
+ * whether its absence from the findings is evidence that it is gone.
+ *
+ * `pack` and `path` come from the issue's own markers, so both are `null` for
+ * issues filed before those markers existed.
+ *
+ * The unmarked case is decided in the safe direction: on a complete run it is
+ * "scanned", which is exactly today's behaviour and keeps existing installs
+ * byte-identical; on a partial run it is "held", because an issue we cannot
+ * attribute to a file is an issue we cannot prove we looked at. Holding is
+ * recoverable — the issue simply stays open — whereas closing is not.
+ *
+ * In practice unmarked issues do not survive to see a partial run: the cache
+ * that enables partial runs cannot exist on the first run, so that run is
+ * complete, and every issue whose finding still recurs is touched and has its
+ * markers backfilled before any file is ever skipped.
+ */
+export function issueWasScanned(
+	scope: ScanScope | undefined,
+	pack: string | null,
+	path: string | null,
+): boolean {
+	// No scope means the caller is not tracking one: every file was read.
+	if (!scope || isCompleteScope(scope)) {
+		return true;
+	}
+	if (pack === null || path === null) {
+		return false;
+	}
+	if (scope.fullPacks.has(pack)) {
+		return true;
+	}
+	const scanned = scope.scannedByPack.get(pack);
+	// A pack absent from the scope did not run at all this time — the target no
+	// longer names it, or it failed to resolve. That is not an incremental skip,
+	// and its issues should age out as they always have.
+	if (!scanned) {
+		return true;
+	}
+	return scanned.has(path);
+}

--- a/source/index.ts
+++ b/source/index.ts
@@ -28,9 +28,16 @@ export {
 	SUPPRESSION_LABELS,
 } from './dedup/plan.js';
 export {
+	type ReconcileExecOptions,
 	type ReconcileResult,
 	reconcileFindings,
 } from './dedup/reconcile.js';
+export {
+	fullScope,
+	isCompleteScope,
+	issueWasScanned,
+	type ScanScope,
+} from './dedup/scope.js';
 export type {
 	Confidence,
 	Finding,

--- a/source/issues/file.ts
+++ b/source/issues/file.ts
@@ -40,16 +40,41 @@ export function targetRepoFor(
 	return context.auditedRepo;
 }
 
+/**
+ * The markers that let a later run decide whether this issue's subject was
+ * actually re-examined. The file is already in the body as prose, but prose is
+ * not a contract — parsing it back would break the first time the template
+ * changes, and the pack is not in the body at all.
+ *
+ * `pack` comes from {@link FilingContext} rather than the finding's rule
+ * prefix: the rule is whatever the model wrote, and scope is keyed by the pack
+ * that actually ran.
+ */
+export function withScopeMarkers(
+	body: string,
+	finding: Finding,
+	context: FilingContext,
+): string {
+	const withPath = upsertMarker(body, 'path', finding.file);
+	return context.pack === undefined
+		? withPath
+		: upsertMarker(withPath, 'pack', context.pack);
+}
+
 /** Render one finding into filable issue content. */
 export function buildIssueContent(
 	finding: Finding,
 	config: SentinelConfig,
 	context: FilingContext,
 ): IssueContent {
-	const body = upsertMarker(
-		buildIssueBody(finding, context),
-		'hash',
-		findingHash(finding),
+	const body = withScopeMarkers(
+		upsertMarker(
+			buildIssueBody(finding, context),
+			'hash',
+			findingHash(finding),
+		),
+		finding,
+		context,
 	);
 	return {
 		title: buildIssueTitle(finding),

--- a/source/issues/types.ts
+++ b/source/issues/types.ts
@@ -89,6 +89,14 @@ export interface FilingContext {
 	configRepo?: string;
 	/** The version of the rule pack that produced the finding, for the body. */
 	packVersion?: string;
+	/**
+	 * The name of the rule pack that produced the finding. Written into the issue
+	 * as a marker so a later, partial run can tell whether this issue's file was
+	 * one that pack actually read — see `dedup/scope.ts`. Absent when the caller
+	 * cannot attribute the finding to a pack, which leaves the issue unmarked and
+	 * therefore held rather than aged out on any run that skipped files.
+	 */
+	pack?: string;
 }
 
 /** A finding paired with the issue it was filed as. */

--- a/source/observe/record.spec.ts
+++ b/source/observe/record.spec.ts
@@ -49,6 +49,7 @@ function result(overrides: Partial<ReconcileResult> = {}): ReconcileResult {
 		touched: 0,
 		incremented: 0,
 		resolved: 0,
+		held: 0,
 		suppressed: 0,
 		suppressedByOverride: 0,
 		errors: [],
@@ -257,4 +258,31 @@ test('a clean run records no packLoadErrors field at all', t => {
 	// not have to tell "clean" from "written before this existed".
 	const built = buildRunRecord(report(), TS, 'live');
 	t.false('packLoadErrors' in built);
+});
+
+test('a run that held nothing writes no held key', t => {
+	// Absent is not zero. A record without the field cannot say whether the run
+	// held nothing or predates the field, and the record is the durable artifact
+	// — the same reason packLoadErrors is optional rather than defaulted.
+	const record = buildRunRecord(
+		report({filed: true, reconciled: [{repo: 'org/a', result: result()}]}),
+		'2026-07-21T06:00:00.000Z',
+		'live',
+	);
+	t.false('held' in (record.filing ?? {}));
+});
+
+test('held issues are carried into the durable record', t => {
+	const record = buildRunRecord(
+		report({
+			filed: true,
+			reconciled: [
+				{repo: 'org/a', result: result({held: 2})},
+				{repo: 'org/b', result: result({held: 3})},
+			],
+		}),
+		'2026-07-21T06:00:00.000Z',
+		'live',
+	);
+	t.is(record.filing?.held, 5, 'summed across repos');
 });

--- a/source/observe/record.ts
+++ b/source/observe/record.ts
@@ -105,6 +105,7 @@ export function buildRunRecord(
 			suppressedByOverride: 0,
 			resolved: 0,
 		};
+		let held = 0;
 		for (const {result} of report.reconciled) {
 			filing.filed += result.created.length;
 			filing.touched += result.touched;
@@ -112,6 +113,13 @@ export function buildRunRecord(
 			filing.suppressed += result.suppressed;
 			filing.suppressedByOverride += result.suppressedByOverride;
 			filing.resolved += result.resolved;
+			held += result.held;
+		}
+		// Only recorded when something was actually held. A run that read every
+		// file writes no `held` key, so the field means "this run skipped files
+		// and here is what that cost" rather than a zero on every record.
+		if (held > 0) {
+			filing.held = held;
 		}
 		record.filing = filing;
 	}

--- a/source/observe/types.ts
+++ b/source/observe/types.ts
@@ -52,6 +52,16 @@ export interface FilingSummary {
 	suppressed: number;
 	suppressedByOverride: number;
 	resolved: number;
+	/**
+	 * Open issues left untouched because the run did not read their file.
+	 *
+	 * Optional because records written before incremental scanning existed have
+	 * no such field, and absent is not the same as zero: a record without it
+	 * cannot tell you whether the run held nothing or was simply too old to know.
+	 * The record is the durable artifact, so that distinction has to survive in
+	 * it — the same reason `packLoadErrors` is optional rather than defaulted.
+	 */
+	held?: number;
 }
 
 /** A committed record of one Sentinel run. */

--- a/source/run/preview.spec.ts
+++ b/source/run/preview.spec.ts
@@ -169,3 +169,67 @@ test('a dry run with no pack problems shows no pack warnings', t => {
 	t.false(md.includes('Missing packs'));
 	t.false(md.includes('did not resolve'));
 });
+
+test('a dry run reports what it would hold', t => {
+	const gone = finding('unscanned.rs');
+	let body = upsertMarker('body', 'hash', findingHash(gone));
+	body = upsertMarker(upsertMarker(body, 'pack', 'p'), 'path', 'unscanned.rs');
+	const preview = previewReconciliation(
+		[],
+		config(),
+		[{number: 1, url: 'u', state: 'open', labels: ['sentinel'], body}],
+		undefined,
+		{
+			scope: {
+				scannedByPack: new Map([['p', new Set(['other.rs'])]]),
+				fullPacks: new Set(),
+			},
+		},
+	);
+	t.is(preview.wouldHold, 1);
+	t.is(preview.wouldResolve, 0);
+});
+
+test('renderPreview stays silent about holds when there are none', t => {
+	// A line reading "would hold: 0" on every complete run is noise, and noise
+	// is what stops the interesting case being noticed.
+	const markdown = renderPreview([
+		{
+			repo: 'org/a',
+			preview: {
+				wouldFileAsNew: [],
+				dedupWouldMatch: [],
+				belowThreshold: [],
+				suppressedByOverride: [],
+				suppressedByLabel: [],
+				wouldResolve: 0,
+				wouldHold: 0,
+			},
+			failedPacks: [],
+			missingPacks: [],
+			unresolvedPacks: [],
+		},
+	]);
+	t.false(markdown.includes('Would hold'));
+});
+
+test('renderPreview surfaces holds when there are some', t => {
+	const markdown = renderPreview([
+		{
+			repo: 'org/a',
+			preview: {
+				wouldFileAsNew: [],
+				dedupWouldMatch: [],
+				belowThreshold: [],
+				suppressedByOverride: [],
+				suppressedByLabel: [],
+				wouldResolve: 0,
+				wouldHold: 3,
+			},
+			failedPacks: [],
+			missingPacks: [],
+			unresolvedPacks: [],
+		},
+	]);
+	t.true(markdown.includes('Would hold:** 3'));
+});

--- a/source/run/preview.ts
+++ b/source/run/preview.ts
@@ -28,6 +28,11 @@ export interface DryRunPreview {
 	suppressedByLabel: Finding[];
 	/** Open issues a live run would auto-resolve as stale. */
 	wouldResolve: number;
+	/**
+	 * Open issues a live run would leave alone because it did not read their
+	 * file. Zero whenever the run read everything.
+	 */
+	wouldHold: number;
 }
 
 /** Compute the dry-run preview for one repo's findings. */
@@ -63,6 +68,7 @@ export function previewReconciliation(
 		suppressedByOverride,
 		suppressedByLabel: plan.suppressed,
 		wouldResolve: plan.toResolve.length,
+		wouldHold: plan.held.length,
 	};
 }
 
@@ -141,6 +147,12 @@ export function renderPreview(previews: PreviewEntry[]): string {
 				group('Suppressed by a prior dismissal', preview.suppressedByLabel),
 				'',
 				`**Would auto-resolve:** ${preview.wouldResolve} stale issue(s)`,
+				...(preview.wouldHold > 0
+					? [
+							'',
+							`**Would hold:** ${preview.wouldHold} open issue(s) whose file this run did not read — neither refreshed nor aged`,
+						]
+					: []),
 				failureBlock(failedPacks),
 			].join('\n'),
 		);

--- a/source/run/report.spec.ts
+++ b/source/run/report.spec.ts
@@ -50,6 +50,7 @@ function result(overrides: Partial<ReconcileResult> = {}): ReconcileResult {
 		touched: 0,
 		incremented: 0,
 		resolved: 0,
+		held: 0,
 		suppressed: 0,
 		suppressedByOverride: 0,
 		errors: [],
@@ -72,15 +73,24 @@ test('renders every filing counter in the per-repo line', t => {
 				suppressed: 1,
 			}),
 		),
-		'myorg/myrepo: filed 3, touched 5, aged 2, suppressed 1, suppressed-by-override 0, resolved 0',
+		'myorg/myrepo: filed 3, touched 5, aged 2, held 0, suppressed 1, suppressed-by-override 0, resolved 0',
 	);
 });
 
 test('prints zeroed counters rather than omitting them', t => {
 	t.is(
 		renderFilingLine('org/a', result()),
-		'org/a: filed 0, touched 0, aged 0, suppressed 0, suppressed-by-override 0, resolved 0',
+		'org/a: filed 0, touched 0, aged 0, held 0, suppressed 0, suppressed-by-override 0, resolved 0',
 	);
+});
+
+test('held issues are counted apart from aged ones', t => {
+	// An aged issue is one Sentinel looked for and did not find; a held issue is
+	// one it never looked for. Reporting them as one number would hide exactly
+	// the distinction the scope machinery exists to make.
+	const line = renderFilingLine('org/a', result({incremented: 1, held: 4}));
+	t.true(line.includes('aged 1'));
+	t.true(line.includes('held 4'));
 });
 
 test('names the audited repo, not the issue target', t => {

--- a/source/run/report.ts
+++ b/source/run/report.ts
@@ -134,6 +134,7 @@ export function renderFilingLine(
 		`${repo}: filed ${result.created.length}`,
 		`touched ${result.touched}`,
 		`aged ${result.incremented}`,
+		`held ${result.held}`,
 		`suppressed ${result.suppressed}`,
 		`suppressed-by-override ${result.suppressedByOverride}`,
 		`resolved ${result.resolved}`,

--- a/source/run/run.spec.ts
+++ b/source/run/run.spec.ts
@@ -1,5 +1,6 @@
 import test from 'ava';
 import type {SentinelConfig} from '../config/types.js';
+import {readMarker} from '../dedup/markers.js';
 import type {
 	CreatedIssue,
 	CreateIssueParams,
@@ -493,4 +494,42 @@ test('runLocal reports no pack-selection problems', async t => {
 	);
 	t.deepEqual(outcome.repos[0]?.unresolvedPacks, []);
 	t.deepEqual(outcome.repos[0]?.missingPacks, []);
+});
+
+test('a filed issue is attributed to the pack that produced it', async t => {
+	// The integration proof that the plumbing is connected: the pack name only
+	// exists in the per-pack outcomes, and the findings are flat by the time
+	// reconciliation sees them. If the run does not carry the attribution across
+	// that flattening, every issue files unmarked and every later partial run
+	// holds everything forever.
+	const {client, created} = fakeClient();
+	await runFromConfig(
+		config(),
+		{
+			runner: findingRunner(),
+			files: repoFiles(),
+			packs: packLoader({packs: [pack('p')], errors: []}),
+			client,
+			now: NOW,
+		},
+		OPTIONS,
+	);
+	t.is(readMarker(created[0]?.body ?? '', 'pack'), 'p');
+	t.not(readMarker(created[0]?.body ?? '', 'path'), null);
+});
+
+test('a config-driven run holds nothing, because it reads everything', async t => {
+	const {client} = fakeClient();
+	const report = await runFromConfig(
+		config(),
+		{
+			runner: findingRunner(),
+			files: repoFiles(),
+			packs: packLoader({packs: [pack('p')], errors: []}),
+			client,
+			now: NOW,
+		},
+		OPTIONS,
+	);
+	t.is(report.reconciled[0]?.result.held, 0);
 });

--- a/source/run/run.ts
+++ b/source/run/run.ts
@@ -12,6 +12,8 @@ import {join} from 'node:path';
 import {parseRepoOverride} from '../config/repo-override.js';
 import type {RepoOverride, SentinelConfig} from '../config/types.js';
 import {type ReconcileResult, reconcileFindings} from '../dedup/reconcile.js';
+import {fullScope} from '../dedup/scope.js';
+import type {Finding} from '../findings/types.js';
 import {targetRepoFor} from '../issues/file.js';
 import type {FilingContext, ReconcileClient} from '../issues/types.js';
 import type {AutoFixOptions} from '../orchestrator/auto-fix.js';
@@ -165,6 +167,20 @@ export async function runFromConfig(
 			continue;
 		}
 		const findings = packOutcomes.flatMap(outcome => outcome.findings);
+		// Which pack produced each finding, and what each pack read. Both are
+		// known here and nowhere downstream: `findings` is flat by the time it
+		// reaches reconciliation, and the flattening is what loses the pack.
+		const packOfFinding = new Map<Finding, string>();
+		for (const outcome of packOutcomes) {
+			for (const finding of outcome.findings) {
+				packOfFinding.set(finding, outcome.pack);
+			}
+		}
+		// Every pack read everything it applies to: this path does not skip files
+		// yet, so the scope is complete and reconciliation is unchanged. The
+		// plumbing lands first so that the incremental cache cannot be introduced
+		// without it.
+		const scope = fullScope(packOutcomes.map(outcome => outcome.pack));
 		const override = await readOverride(deps.files, repoDir);
 		const context: FilingContext = {
 			auditedRepo: repoName,
@@ -178,7 +194,11 @@ export async function runFromConfig(
 				deps.client,
 				context,
 				deps.now,
-				{resolveAfterMisses: options.resolveAfterMisses},
+				{
+					resolveAfterMisses: options.resolveAfterMisses,
+					scope,
+					packOfFinding,
+				},
 				override,
 			);
 			reconciled.push({repo: repoName, result});
@@ -195,6 +215,7 @@ export async function runFromConfig(
 				override,
 				{
 					resolveAfterMisses: options.resolveAfterMisses,
+					scope,
 				},
 			);
 			const failedPacks: PackFailure[] = packOutcomes


### PR DESCRIPTION
The blocker from #17, landed on its own. **No behaviour changes today** — every run still reads every file, so every scope is complete and nothing is ever held.

## The bug

`planReconciliation` sees this run's findings and the currently open issues, and nothing else. It cannot tell **"the finding is gone"** from **"the file was not read"** — both arrive as an absent finding, both bump the miss counter, and at `resolveAfterMisses` the issue is closed as fixed.

Harmless while every run reads every file. Catastrophic the moment one does not — which is exactly what incremental scanning proposes to do. On a daily schedule, skipping unchanged files would auto-close real, unfixed findings after three runs: the tool quietly reporting a vulnerability as fixed because it stopped looking.

## The fix

A run carries the scope it read. An open issue whose file was not read is **held** — neither refreshed nor aged, miss counter left exactly where it was. Holding is recoverable; auto-closing a real finding is not.

**Scope is per rule pack, not per repository.** This is the part that is easy to get wrong. Packs do not read the same files, so a repo-wide scope would call `src/db.ts` "scanned" for a pack that never opened it — reintroducing the bug for any repo running more than one pack. There is a test for exactly this.

Holding is also deliberately narrow: a finding that genuinely stopped recurring **in a file the run did read** still ages out and still auto-resolves. Otherwise auto-resolution dies the moment incremental scanning is switched on.

## Two decisions worth review

**1. `pack` as well as `path`.** #17 proposed a `path` marker. Scope has to be per-pack to be correct, so the pack has to be on the issue too. It comes from `FilingContext` rather than the finding's rule prefix, because the rule is whatever the model wrote while scope is keyed by the pack that actually ran.

Threading it needed the one non-obvious change here: `run.ts` flattens `packOutcomes.flatMap(o => o.findings)` before reconciliation, and *that flattening is what loses the pack*. It is now captured before the flatten and passed down. There is an integration test asserting a filed issue is attributed to its pack, because this is the piece that silently degrades if it breaks.

**2. Unmarked issues are held on a partial run, not aged.** #17 suggested treating an issue with no marker as always in scope, so pre-existing issues "keep today's behaviour and age out normally... and the marker backfills naturally as issues are touched."

I think that has a hole. **An issue only gets touched when its finding recurs, which requires its file to be read.** With incremental scanning on, an issue in an unchanged file is never touched, so it never backfills — and it ages out in three runs. The issues the migration leaves behind are exactly the ones at risk.

So the unmarked case splits by run type:

- **complete run → scanned.** Byte-identical to today, which is what makes this PR a no-op.
- **partial run → held.** An issue we cannot attribute to a file is one we cannot prove we looked at.

The "held forever" worry that motivated #17's suggestion is bounded by an invariant worth stating: **the cache that enables partial runs cannot exist on the first run**, so that run reads everything, and every issue whose finding still recurs is touched and marked before any file is ever skipped. Touching now backfills both markers, which is what closes the loop.

## Reporting

`held` is counted apart from `aged` in the run summary, dry-run preview, run record and dashboard. `aged` means Sentinel looked and did not find; `held` means it did not look. Collapsing them would hide the distinction this exists to draw.

The record's `held` key is written only when something was held — absent is not zero, same posture as `packLoadErrors`.

The dry run stays silent about holds when there are none, so the line appearing is itself the signal.

## On splitting this from the cache

#17 says the fix must land in the same PR as the cache. The risk it guards against is a cache shipping without the fix; **fix-first inverts that and carries none of it** — this PR cannot skip a file. It is also far more reviewable than one change carrying both. The cache is next and depends on this.

## Verification

- 447 → 460 tests, `scope.ts` and `plan.ts` at 100% line and branch coverage, project at 97.4%.
- The acceptance property from #17 — reconciliation across several incremental runs asserting the issue stays open — is tested, and the counter is asserted to have never moved, not merely to be under the threshold.
- **I confirmed the tests catch the regression** by disabling the hold branch: 3 fail, including the acceptance test. A test that passes with and without the fix would prove nothing.
- Full gate green: types (source and specs), lint, format, knip, `pnpm audit`, Semgrep 0 findings.
