### PR TITLE
feat(incremental): re-audit only what changed since the last successful pass

### DIFF
--- a/.changeset/incremental-scanning.md
+++ b/.changeset/incremental-scanning.md
@@ -1,0 +1,37 @@
+---
+"@nanocollective/sentinel": patch
+---
+
+- **Incremental scanning.** A target can set `incremental: true` to re-audit
+  only the files that changed since its last successful pass, instead of reading
+  a whole repository every night. Off by default and opt-in per target: it
+  trades a complete re-read for speed, and that is a trade to make on a
+  repository you know rather than to inherit.
+
+  This is only safe because auto-resolution now knows what a run read. An open
+  issue whose file was skipped is **held** rather than aged towards closing —
+  without that, switching this on would auto-close real, unfixed findings after
+  three runs.
+
+  Every uncertain case reads everything, because the two mistakes are not the
+  same size: being wrong about needing to re-read costs model time, being wrong
+  about not needing to costs a missed finding. A pack re-reads in full when
+  there is no cached pass, when its version or body changed, when a pack it
+  `depends_on` changed, when the cached commit is unreachable (a shallow clone,
+  or a force-push that orphaned it), or when `--full` is passed.
+
+  - **A pack whose audit failed records nothing.** Advancing the cache after an
+    errored pass would let the next run skip files on the strength of an audit
+    that never happened.
+  - **The run report says which packs re-read everything, and why**, so a target
+    that opted in and got no speed-up explains itself rather than looking broken.
+  - A repository matching several targets is incremental only if *every* one of
+    them opted in, so an unrelated pattern cannot cause a target's files to be
+    skipped.
+  - The cache is a committed JSON file beside the run records — no database. A
+    cache that is missing, unreadable, or written by a newer schema is treated as
+    empty, which means a full read.
+  - A dry run neither reads nor writes it: a preview must not narrow a later
+    audit, nor record a pass it did not make.
+
+  New flags: `--full` to force a complete pass, `--cache-file` to move the cache.

--- a/.changeset/incremental-scanning.md
+++ b/.changeset/incremental-scanning.md
@@ -16,15 +16,22 @@
   Every uncertain case reads everything, because the two mistakes are not the
   same size: being wrong about needing to re-read costs model time, being wrong
   about not needing to costs a missed finding. A pack re-reads in full when
-  there is no cached pass, when its version or body changed, when a pack it
-  `depends_on` changed, when the cached commit is unreachable (a shallow clone,
-  or a force-push that orphaned it), or when `--full` is passed.
+  there is no cached pass, when the pack changed, when a pack it `depends_on`
+  changed, when the cached commit is unreachable (a shallow clone, or a
+  force-push that orphaned it), or when `--full` is passed.
+
+  "The pack changed" covers its prompt body, `applies_to`, `severity_weighting`
+  and `category` as well as its version — deliberately not resting on an author
+  remembering to bump. Widening `applies_to` in place would otherwise leave
+  every newly-applicable file skipped indefinitely.
 
   - **A pack whose audit failed records nothing.** Advancing the cache after an
     errored pass would let the next run skip files on the strength of an audit
     that never happened.
-  - **The run report says which packs re-read everything, and why**, so a target
-    that opted in and got no speed-up explains itself rather than looking broken.
+  - **The run report, the durable run record and the dashboard all say which
+    packs re-read everything, and why**, so a target that opted in and got no
+    speed-up explains itself rather than looking broken. The report is a step
+    summary that expires; the record is what an operator still has a week later.
   - A repository matching several targets is incremental only if *every* one of
     them opted in, so an unrelated pattern cannot cause a target's files to be
     skipped.

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -51,6 +51,10 @@ npx @nanocollective/sentinel run \
 | `--repo <path>` | Path to the repository to audit (a local checkout). |
 | `--output <path>` | Where to write the findings Markdown. Defaults to stdout / a local file. |
 | `--dry-run` | In the Actions context, do the full audit but file no issues (see [run modes](../workflow/index.md#run-modes)). |
+| `--full` | Re-audit every file, ignoring the [incremental cache](../configuration/index.md#incremental). Always available, and the way back to a complete pass on demand. |
+| `--cache-file <path>` | Where the incremental cache lives. Defaults to `./.sentinel-cache.json`. |
+
+A dry run neither reads nor writes the incremental cache: a preview must not narrow a later audit, and must not record a pass it did not make.
 
 ### Local run vs. Actions run
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -53,8 +53,40 @@ A list of repositories to audit. Each entry is either an explicit `repo:` or a `
 | `repo` | A single `owner/name` repository. |
 | `pattern` | A glob matching multiple repositories in the org. Combine with allow/deny as needed. |
 | `rule_packs` | The list of pack names (from `rule-packs/`) to run against this target. |
+| `incremental` | Re-audit only files that changed since the last successful pass. Off by default — see below. |
 
 A repo's assigned packs, combined with each pack's `applies_to.paths`, determine which files are read. See [Rule Packs](../rule-packs/index.md#assigning-packs-to-repositories).
+
+#### `incremental`
+
+Re-auditing a whole repository when a handful of files moved is the dominant cost as an install grows. Setting `incremental: true` on a target limits each pack to the files that changed since that pack last completed a pass.
+
+```yaml
+targets:
+  - repo: my-org/my-program
+    rule_packs: [solana-anchor, rust-general]
+    incremental: true
+```
+
+It is **off by default and opt-in per target**, because it trades a complete re-read for speed, and that is a trade to make on a repository you know rather than to inherit.
+
+**A pack re-reads everything whenever anything is uncertain.** Being wrong about needing to re-read costs some model time; being wrong about *not* needing to costs a missed finding. Those are not close, so a full pass happens when:
+
+- the target has no cached pass yet (the first run, always);
+- the pack's version or body changed — an edited prompt asks a different question, and every file has to answer it again;
+- a pack it `depends_on` changed, for the same reason: a dependency's body is part of this pack's prompt;
+- the cached commit is unreachable — a shallow clone, or a force-push that orphaned it. *Cannot tell* is not *nothing changed*;
+- `--full` was passed.
+
+The run report says which packs re-read everything and why, so a target that opted in and got no speed-up explains itself.
+
+A pack whose audit **failed** records nothing. Advancing the cache after an errored pass would let the next run skip files on the strength of an audit that never happened.
+
+If a repository matches several targets, incremental applies only when **every** one of them opted in — otherwise a target expecting a complete re-read would quietly stop getting one.
+
+The cache is a JSON file (`.sentinel-cache.json` by default, `--cache-file` to move it) committed to the configuration repo beside the run records. There is no database. A cache that is missing, unreadable or written by a newer schema is treated as empty, which means the run reads everything.
+
+Skipping files is only safe because auto-resolution knows what was read: an open issue whose file this run did not read is **held** rather than aged towards being closed. See [findings](../findings/index.md#auto-resolution-only-counts-runs-that-looked).
 
 ### `schedule`
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -73,7 +73,7 @@ It is **off by default and opt-in per target**, because it trades a complete re-
 **A pack re-reads everything whenever anything is uncertain.** Being wrong about needing to re-read costs some model time; being wrong about *not* needing to costs a missed finding. Those are not close, so a full pass happens when:
 
 - the target has no cached pass yet (the first run, always);
-- the pack's version or body changed — an edited prompt asks a different question, and every file has to answer it again;
+- the pack changed — its version, its prompt body, its `applies_to`, its `severity_weighting` or its `category`. A pack edited in place asks a different question, or asks it of different files, and either way the answers have to be redone. Notably this does **not** rely on you bumping the version: widening `applies_to` without a bump would otherwise leave the newly-applicable files skipped indefinitely;
 - a pack it `depends_on` changed, for the same reason: a dependency's body is part of this pack's prompt;
 - the cached commit is unreachable — a shallow clone, or a force-push that orphaned it. *Cannot tell* is not *nothing changed*;
 - `--full` was passed.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,4 +22,4 @@ onlyBuiltDependencies:
   - '@biomejs/biome'
   - esbuild
 
-auditConfig: {}
+auditConfig: { ignoreGhsas: null }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,4 +22,4 @@ onlyBuiltDependencies:
   - '@biomejs/biome'
   - esbuild
 
-auditConfig: { ignoreGhsas: null }
+auditConfig: {}

--- a/source/cli.ts
+++ b/source/cli.ts
@@ -23,6 +23,9 @@ import {createInterface} from 'node:readline/promises';
 import {flagAll, flagBool, flagStr, parseFlags} from './args/flags.js';
 import {loadConfigFrom} from './config/load.js';
 import type {ModelConfig, SentinelConfig} from './config/types.js';
+import {parseCache, serialiseCache} from './incremental/cache.js';
+import {gitProbe} from './incremental/git.js';
+import {CacheSession} from './incremental/session.js';
 import {parseInitArgs} from './init/args.js';
 import {scaffold} from './init/scaffold.js';
 import type {InitOptions} from './init/types.js';
@@ -146,7 +149,9 @@ Options:
   --config-repo <o/n>   Config repo, for routing (default $GITHUB_REPOSITORY)
   --provider <name>     Local mode model provider (default ollama)
   --model <id>          Local mode model id (default llama3.1:70b)
-  --dry-run             Audit but file no issues`;
+  --dry-run             Audit but file no issues
+  --full                Re-audit every file, ignoring the incremental cache
+  --cache-file <path>   Incremental cache (default ./.sentinel-cache.json)`;
 
 /** Load sentinel.yaml, printing every failure mode through one path. */
 function loadConfig(configPath: string): SentinelConfig | null {
@@ -169,6 +174,23 @@ function writeReport(markdown: string, output: string | undefined): void {
 	} else {
 		console.log(markdown);
 	}
+}
+
+/**
+ * Read the incremental cache. A missing or unreadable file is an empty cache,
+ * which makes the run read everything — the safe direction, and the reason this
+ * never reports an error: there is nothing for an operator to act on when the
+ * outcome is a complete audit.
+ */
+function readCache(path: string): CacheSession {
+	const text = existsSync(path) ? readFileSync(path, 'utf8') : null;
+	return new CacheSession(parseCache(text), gitProbe);
+}
+
+function writeCache(session: CacheSession, path: string): void {
+	mkdirSync(dirname(path), {recursive: true});
+	writeFileSync(path, serialiseCache(session.result()));
+	console.log(`Wrote incremental cache to ${path}`);
 }
 
 function writeRunRecord(record: RunRecord, recordsDir: string): void {
@@ -245,6 +267,16 @@ async function runRun(argv: string[]): Promise<number> {
 	const workspace = flagStr(flags, 'workspace') ?? '.';
 	const noClone = flagBool(flags, 'no-clone');
 
+	// The cache is only consulted when a target opted in, but it is loaded either
+	// way so that a run which is not yet incremental still records where each
+	// pack got to. Without that, switching `incremental: true` on would always
+	// find an empty cache and read everything anyway.
+	//
+	// A dry run neither reads nor writes it: a preview must not narrow a later
+	// audit, and must not record a pass it did not make.
+	const cachePath = flagStr(flags, 'cache-file') ?? '.sentinel-cache.json';
+	const cache = dryRun ? undefined : readCache(cachePath);
+
 	// The client is available whenever a token is present — a dry run uses it to
 	// read existing issues for the preview, a live run to file.
 	const hasToken = Boolean(process.env.GITHUB_TOKEN);
@@ -258,6 +290,7 @@ async function runRun(argv: string[]): Promise<number> {
 			client: hasToken ? ghIssueClient : undefined,
 			repoLister: ghRepoLister,
 			cloneRepo: noClone ? undefined : prepareRepo,
+			cache,
 			now,
 		},
 		{
@@ -273,8 +306,13 @@ async function runRun(argv: string[]): Promise<number> {
 				? Number(flagStr(flags, 'resolve-after-misses'))
 				: undefined,
 			dryRun,
+			full: flagBool(flags, 'full'),
 		},
 	);
+
+	if (cache) {
+		writeCache(cache, cachePath);
+	}
 
 	// Dry run with a token renders the grouped preview; otherwise the plain
 	// findings report.

--- a/source/config/parse.spec.ts
+++ b/source/config/parse.spec.ts
@@ -177,3 +177,32 @@ model:
 	t.false(result.valid);
 	t.true(result.errors.some(e => e.field === 'model.fallback'));
 });
+
+test('a target defaults to non-incremental', t => {
+	// Opt-in, not opt-out: skipping files is a trade the operator makes on a
+	// repository they know, and an absent key must never make it for them.
+	const result = parseConfig(FULL_CONFIG);
+	t.is(result.config?.targets[0]?.incremental, undefined);
+});
+
+test('a target can opt in to incremental scanning', t => {
+	const result = parseConfig(
+		FULL_CONFIG.replace(
+			'    rule_packs: [solana-anchor, rust-general]',
+			'    rule_packs: [solana-anchor, rust-general]\n    incremental: true',
+		),
+	);
+	t.true(result.valid);
+	t.true(result.config?.targets[0]?.incremental);
+});
+
+test('a non-boolean incremental is rejected', t => {
+	const result = parseConfig(
+		FULL_CONFIG.replace(
+			'    rule_packs: [solana-anchor, rust-general]',
+			'    rule_packs: [solana-anchor, rust-general]\n    incremental: "yes"',
+		),
+	);
+	t.false(result.valid);
+	t.true(result.errors.some(error => error.field === 'targets[0].incremental'));
+});

--- a/source/config/parse.ts
+++ b/source/config/parse.ts
@@ -102,7 +102,20 @@ function validateTarget(
 		}
 	}
 
+	if (
+		value.incremental !== undefined &&
+		typeof value.incremental !== 'boolean'
+	) {
+		errors.push({
+			field: `${field}.incremental`,
+			message: 'incremental must be a boolean',
+		});
+	}
+
 	const target: Target = {rulePacks};
+	if (typeof value.incremental === 'boolean') {
+		target.incremental = value.incremental;
+	}
 	if (hasRepo && typeof value.repo === 'string') {
 		target.repo = value.repo;
 	}

--- a/source/config/types.ts
+++ b/source/config/types.ts
@@ -15,6 +15,15 @@ export interface Target {
 	pattern?: string;
 	/** The rule pack names to run against this target. */
 	rulePacks: string[];
+	/**
+	 * Re-audit only files that changed since this target's last successful pass.
+	 *
+	 * Off by default, and opt-in per target rather than globally: it trades a
+	 * complete re-read for speed, and that trade is the operator's to make on a
+	 * repository they know. A target that does not set it behaves exactly as it
+	 * always has.
+	 */
+	incremental?: boolean;
 }
 
 /** An optional cloud fallback, used only when the primary model struggles. */

--- a/source/dedup/scope.ts
+++ b/source/dedup/scope.ts
@@ -32,6 +32,11 @@ export interface ScanScope {
 	fullPacks: Set<string>;
 }
 
+/** A scope nothing has been recorded into yet. */
+export function emptyScope(): ScanScope {
+	return {scannedByPack: new Map(), fullPacks: new Set()};
+}
+
 /** A scope in which every named pack read everything it applies to. */
 export function fullScope(packs: Iterable<string>): ScanScope {
 	return {scannedByPack: new Map(), fullPacks: new Set(packs)};

--- a/source/incremental/cache.spec.ts
+++ b/source/incremental/cache.spec.ts
@@ -1,0 +1,95 @@
+import test from 'ava';
+import {lookup, parseCache, record, serialiseCache} from './cache.js';
+import {CACHE_VERSION, emptyCache, type PackCacheEntry} from './types.js';
+
+console.log('\nincremental/cache.spec.ts');
+
+function entry(overrides: Partial<PackCacheEntry> = {}): PackCacheEntry {
+	return {
+		pack: 'db-safety',
+		packVersion: '1.0.0',
+		bodyHash: 'aaaa',
+		dependencyHash: 'bbbb',
+		sha: 'sha-1',
+		...overrides,
+	};
+}
+
+test('a missing cache file is an empty cache', t => {
+	t.deepEqual(parseCache(null), emptyCache());
+});
+
+test('malformed JSON is an empty cache, not a crash', t => {
+	// An unreadable cache must degrade to reading everything. Throwing here would
+	// take down a scheduled audit over a file whose only job is to make it faster.
+	t.deepEqual(parseCache('{not json'), emptyCache());
+});
+
+test('a cache from an unknown schema version is discarded', t => {
+	// The safe direction: a shape whose meaning may have changed is not trusted,
+	// so the run reads everything and rebuilds it.
+	t.deepEqual(
+		parseCache(JSON.stringify({version: CACHE_VERSION + 1, repos: []})),
+		emptyCache(),
+	);
+});
+
+test('a cache with no repos array is discarded', t => {
+	t.deepEqual(
+		parseCache(JSON.stringify({version: CACHE_VERSION})),
+		emptyCache(),
+	);
+});
+
+test('a well-formed cache round-trips', t => {
+	const cache = record(emptyCache(), 'org/a', entry());
+	t.deepEqual(parseCache(serialiseCache(cache)), cache);
+});
+
+test('lookup finds an entry by repo and pack', t => {
+	const cache = record(emptyCache(), 'org/a', entry());
+	t.is(lookup(cache, 'org/a', 'db-safety')?.sha, 'sha-1');
+});
+
+test('lookup does not cross repositories', t => {
+	const cache = record(emptyCache(), 'org/a', entry());
+	t.is(lookup(cache, 'org/b', 'db-safety'), undefined);
+});
+
+test('lookup does not cross packs', t => {
+	const cache = record(emptyCache(), 'org/a', entry());
+	t.is(lookup(cache, 'org/a', 'other-pack'), undefined);
+});
+
+test('recording the same pack twice replaces rather than duplicates', t => {
+	let cache = record(emptyCache(), 'org/a', entry({sha: 'sha-1'}));
+	cache = record(cache, 'org/a', entry({sha: 'sha-2'}));
+	t.is(cache.repos[0]?.packs.length, 1);
+	t.is(lookup(cache, 'org/a', 'db-safety')?.sha, 'sha-2');
+});
+
+test('recording a second pack keeps the first', t => {
+	let cache = record(emptyCache(), 'org/a', entry());
+	cache = record(cache, 'org/a', entry({pack: 'other', sha: 'sha-2'}));
+	t.is(cache.repos[0]?.packs.length, 2);
+	t.is(lookup(cache, 'org/a', 'db-safety')?.sha, 'sha-1');
+});
+
+test('recording a second repo keeps the first', t => {
+	let cache = record(emptyCache(), 'org/a', entry());
+	cache = record(cache, 'org/b', entry({sha: 'sha-2'}));
+	t.is(cache.repos.length, 2);
+	t.is(lookup(cache, 'org/a', 'db-safety')?.sha, 'sha-1');
+	t.is(lookup(cache, 'org/b', 'db-safety')?.sha, 'sha-2');
+});
+
+test('record does not mutate the cache it was given', t => {
+	const before = record(emptyCache(), 'org/a', entry({sha: 'sha-1'}));
+	const snapshot = structuredClone(before);
+	record(before, 'org/a', entry({sha: 'sha-2'}));
+	t.deepEqual(before, snapshot);
+});
+
+test('serialised output ends with a newline', t => {
+	t.true(serialiseCache(emptyCache()).endsWith('\n'));
+});

--- a/source/incremental/cache.ts
+++ b/source/incremental/cache.ts
@@ -1,0 +1,84 @@
+/**
+ * Reading and updating the incremental cache. Pure: the CLI owns the file.
+ */
+
+import {
+	CACHE_VERSION,
+	emptyCache,
+	type IncrementalCache,
+	type PackCacheEntry,
+} from './types.js';
+
+/**
+ * Parse a cache file's contents. Anything unreadable, malformed, or written by
+ * a schema this build does not know becomes an empty cache — which forces a
+ * full pass everywhere rather than trusting a shape whose meaning has changed.
+ * Deliberately silent about the difference: both outcomes are "read everything",
+ * and neither can narrow an audit.
+ */
+export function parseCache(text: string | null): IncrementalCache {
+	if (text === null) {
+		return emptyCache();
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text);
+	} catch {
+		return emptyCache();
+	}
+	if (
+		typeof parsed !== 'object' ||
+		parsed === null ||
+		(parsed as {version?: unknown}).version !== CACHE_VERSION ||
+		!Array.isArray((parsed as {repos?: unknown}).repos)
+	) {
+		return emptyCache();
+	}
+	return parsed as IncrementalCache;
+}
+
+/** The cache entry for one pack on one repository, if there is one. */
+export function lookup(
+	cache: IncrementalCache,
+	repo: string,
+	pack: string,
+): PackCacheEntry | undefined {
+	return cache.repos
+		.find(entry => entry.repo === repo)
+		?.packs.find(entry => entry.pack === pack);
+}
+
+/**
+ * Record that a pack completed a pass over `repo` at `sha`.
+ *
+ * Only ever called for a pass that actually succeeded. A pack whose audit
+ * errored or returned malformed findings has not established that anything was
+ * examined, and writing a commit for it would let the next run skip files on
+ * the strength of a pass that never happened.
+ */
+export function record(
+	cache: IncrementalCache,
+	repo: string,
+	entry: PackCacheEntry,
+): IncrementalCache {
+	const repos = cache.repos.map(existing =>
+		existing.repo === repo
+			? {
+					repo,
+					packs: [
+						...existing.packs.filter(pack => pack.pack !== entry.pack),
+						entry,
+					],
+				}
+			: existing,
+	);
+	if (!repos.some(existing => existing.repo === repo)) {
+		repos.push({repo, packs: [entry]});
+	}
+	return {version: CACHE_VERSION, repos};
+}
+
+/** Serialise the cache for committing. */
+export function serialiseCache(cache: IncrementalCache): string {
+	return `${JSON.stringify(cache, null, 2)}\n`;
+}

--- a/source/incremental/decide.spec.ts
+++ b/source/incremental/decide.spec.ts
@@ -1,0 +1,179 @@
+import test from 'ava';
+import type {RulePack} from '../rule-packs/types.js';
+import {
+	type DecideInput,
+	decidePackScope,
+	dependencyHash,
+	explainFullReason,
+	type GitProbe,
+	packBodyHash,
+} from './decide.js';
+import type {PackCacheEntry} from './types.js';
+
+console.log('\nincremental/decide.spec.ts');
+
+function pack(
+	overrides: Partial<RulePack['manifest']> = {},
+	body = 'audit',
+): RulePack {
+	return {
+		manifest: {
+			name: 'db-safety',
+			version: '1.0.0',
+			description: '',
+			appliesTo: {paths: ['**/*.ts'], languages: ['typescript']},
+			severityWeighting: {},
+			dependsOn: [],
+			category: 'security',
+			...overrides,
+		},
+		body,
+	};
+}
+
+/** A probe that reports the given changed paths, or null for "cannot tell". */
+function probe(changed: string[] | null, head = 'abc123'): GitProbe {
+	return {
+		head: () => head,
+		changedSince: () => changed,
+	};
+}
+
+function cached(overrides: Partial<PackCacheEntry> = {}): PackCacheEntry {
+	return {
+		pack: 'db-safety',
+		packVersion: '1.0.0',
+		bodyHash: packBodyHash(pack()),
+		dependencyHash: dependencyHash([]),
+		sha: 'old-sha',
+		...overrides,
+	};
+}
+
+function input(overrides: Partial<DecideInput> = {}): DecideInput {
+	return {
+		pack: pack(),
+		repoDir: '/ws/repo',
+		cached: cached(),
+		dependencies: [],
+		incremental: true,
+		forced: false,
+		probe: probe([]),
+		...overrides,
+	};
+}
+
+test('a target that did not opt in reads everything', t => {
+	const plan = decidePackScope(input({incremental: false}));
+	t.is(plan.kind, 'full');
+	t.is(plan.kind === 'full' ? plan.reason : '', 'incremental-disabled');
+});
+
+test('--full reads everything even with a valid cache', t => {
+	const plan = decidePackScope(input({forced: true}));
+	t.is(plan.kind === 'full' ? plan.reason : '', 'forced');
+});
+
+test('no cache entry reads everything', t => {
+	// The first run in a repository. This is also what guarantees issues filed
+	// before the scope markers existed get marked before any file is skipped.
+	const plan = decidePackScope(input({cached: undefined}));
+	t.is(plan.kind === 'full' ? plan.reason : '', 'no-cache');
+});
+
+test('a bumped pack version reads everything', t => {
+	const plan = decidePackScope(input({cached: cached({packVersion: '0.9.0'})}));
+	t.is(plan.kind === 'full' ? plan.reason : '', 'pack-changed');
+});
+
+test('an edited body with no version bump still reads everything', t => {
+	// Version alone is not enough. A pack whose prompt was edited in place asks
+	// a different question, and answering it needs every file back.
+	const plan = decidePackScope(
+		input({cached: cached({bodyHash: 'stale-hash'})}),
+	);
+	t.is(plan.kind === 'full' ? plan.reason : '', 'pack-changed');
+});
+
+test('an edited dependency reads everything', t => {
+	// A dependency's body is part of this pack's prompt. Without this, editing a
+	// shared rust-general pack would leave every dependent answering the old
+	// question against files it had already written off as unchanged.
+	const dependency = pack({name: 'ts-general'}, 'new dependency body');
+	const plan = decidePackScope(
+		input({
+			dependencies: [dependency],
+			cached: cached({dependencyHash: dependencyHash([])}),
+		}),
+	);
+	t.is(plan.kind === 'full' ? plan.reason : '', 'dependency-changed');
+});
+
+test('an unchanged dependency does not force a full pass', t => {
+	const dependency = pack({name: 'ts-general'}, 'dependency body');
+	const plan = decidePackScope(
+		input({
+			dependencies: [dependency],
+			cached: cached({dependencyHash: dependencyHash([dependency])}),
+		}),
+	);
+	t.is(plan.kind, 'partial');
+});
+
+test('an unreachable cached commit reads everything', t => {
+	// A shallow clone, or a force-push that orphaned the commit. "Cannot tell"
+	// must never collapse into "nothing changed".
+	const plan = decidePackScope(input({probe: probe(null)}));
+	t.is(plan.kind === 'full' ? plan.reason : '', 'sha-unreachable');
+});
+
+test('a clean cache with no changes scans nothing', t => {
+	const plan = decidePackScope(input({probe: probe([])}));
+	t.deepEqual(plan, {kind: 'partial', paths: []});
+});
+
+test('only changed files the pack applies to are scanned', t => {
+	const plan = decidePackScope(
+		input({probe: probe(['src/a.ts', 'README.md', 'src/b.ts'])}),
+	);
+	t.deepEqual(plan, {kind: 'partial', paths: ['src/a.ts', 'src/b.ts']});
+});
+
+test('a pack with no path patterns takes the whole diff', t => {
+	const plan = decidePackScope(
+		input({
+			pack: pack({appliesTo: {paths: [], languages: []}}),
+			cached: cached({
+				bodyHash: packBodyHash(pack({appliesTo: {paths: [], languages: []}})),
+			}),
+			probe: probe(['src/a.ts', 'README.md']),
+		}),
+	);
+	t.deepEqual(plan, {kind: 'partial', paths: ['src/a.ts', 'README.md']});
+});
+
+test('dependency order is part of the hash', t => {
+	const a = pack({name: 'a'}, 'body a');
+	const b = pack({name: 'b'}, 'body b');
+	t.not(dependencyHash([a, b]), dependencyHash([b, a]));
+});
+
+test('no dependencies hashes consistently', t => {
+	t.is(dependencyHash([]), dependencyHash([]));
+});
+
+test('every full reason has a sentence', t => {
+	// The report says why a pack read everything. A reason with no sentence
+	// would surface as an empty explanation exactly when someone is asking why
+	// their incremental run was not incremental.
+	for (const reason of [
+		'incremental-disabled',
+		'forced',
+		'no-cache',
+		'pack-changed',
+		'dependency-changed',
+		'sha-unreachable',
+	] as const) {
+		t.true(explainFullReason(reason).length > 0, reason);
+	}
+});

--- a/source/incremental/decide.spec.ts
+++ b/source/incremental/decide.spec.ts
@@ -177,3 +177,41 @@ test('every full reason has a sentence', t => {
 		t.true(explainFullReason(reason).length > 0, reason);
 	}
 });
+
+test('widening applies_to invalidates the cache even without a version bump', t => {
+	// The silent under-audit this guards: a pack widened in place would keep its
+	// cache entry, and every newly-applicable file would go on being skipped.
+	// applies_to decides what gets read, so it has to be part of the identity.
+	const widened = pack({
+		appliesTo: {paths: ['**/*.ts', '**/*.tsx'], languages: ['typescript']},
+	});
+	const plan = decidePackScope(
+		input({
+			pack: widened,
+			cached: cached({bodyHash: packBodyHash(pack())}),
+		}),
+	);
+	t.is(plan.kind === 'full' ? plan.reason : '', 'pack-changed');
+});
+
+test('changing severity_weighting invalidates the cache', t => {
+	const reweighted = pack({severityWeighting: {'sql-injection': 'critical'}});
+	const plan = decidePackScope(
+		input({pack: reweighted, cached: cached({bodyHash: packBodyHash(pack())})}),
+	);
+	t.is(plan.kind === 'full' ? plan.reason : '', 'pack-changed');
+});
+
+test('reordering manifest fields is not a change', t => {
+	// A hash that moved with key order would force a full pass over a manifest
+	// nobody meaningfully edited, which trains people to distrust the cache.
+	const a = pack({severityWeighting: {b: 'high', a: 'low'}});
+	const b = pack({severityWeighting: {a: 'low', b: 'high'}});
+	t.is(packBodyHash(a), packBodyHash(b));
+});
+
+test('reordering applies_to paths is not a change', t => {
+	const a = pack({appliesTo: {paths: ['x.ts', 'y.ts'], languages: []}});
+	const b = pack({appliesTo: {paths: ['y.ts', 'x.ts'], languages: []}});
+	t.is(packBodyHash(a), packBodyHash(b));
+});

--- a/source/incremental/decide.ts
+++ b/source/incremental/decide.ts
@@ -14,9 +14,30 @@ import {matchesGlob} from '../rule-packs/glob.js';
 import type {RulePack} from '../rule-packs/types.js';
 import type {PackCacheEntry} from './types.js';
 
-/** A stable hash of a pack's audit body, for detecting an edited prompt. */
+/**
+ * A stable hash of everything about a pack that changes what an audit reads or
+ * reports: its prompt body, the paths it applies to, and the severities it
+ * declares authoritative.
+ *
+ * `applies_to` matters as much as the body. A pack widened in place to cover
+ * `.tsx` alongside `.ts`, without a version bump, would otherwise keep its
+ * cache entry, and every newly-applicable file would go on being skipped — a
+ * silent under-audit, which is the one outcome this feature may never
+ * produce.
+ */
 export function packBodyHash(pack: RulePack): string {
-	return createHash('sha256').update(pack.body).digest('hex').slice(0, 16);
+	const {appliesTo, severityWeighting, category} = pack.manifest;
+	const salient = JSON.stringify({
+		body: pack.body,
+		paths: [...appliesTo.paths].sort(),
+		languages: [...appliesTo.languages].sort(),
+		// Sorted so a reordered manifest is not read as a changed one.
+		severityWeighting: Object.entries(severityWeighting).sort(([a], [b]) =>
+			a < b ? -1 : a > b ? 1 : 0,
+		),
+		category,
+	});
+	return createHash('sha256').update(salient).digest('hex').slice(0, 16);
 }
 
 /**

--- a/source/incremental/decide.ts
+++ b/source/incremental/decide.ts
@@ -1,0 +1,146 @@
+/**
+ * Decide, per pack, whether this run may skip files — and which.
+ *
+ * Every branch here defaults to a full pass. That asymmetry is the whole design:
+ * being wrong about *needing* to re-read costs some model time, while being
+ * wrong about *not* needing to costs a missed vulnerability and, because
+ * reconciliation ages out what it does not see, eventually an issue closed as
+ * fixed. The cheap mistake and the expensive one are not close, so anything
+ * uncertain reads everything.
+ */
+
+import {createHash} from 'node:crypto';
+import {matchesGlob} from '../rule-packs/glob.js';
+import type {RulePack} from '../rule-packs/types.js';
+import type {PackCacheEntry} from './types.js';
+
+/** A stable hash of a pack's audit body, for detecting an edited prompt. */
+export function packBodyHash(pack: RulePack): string {
+	return createHash('sha256').update(pack.body).digest('hex').slice(0, 16);
+}
+
+/**
+ * A combined hash over the bodies of a pack's dependencies, in the order the
+ * resolver produced them. Order is part of the prompt, so a reordering is a
+ * change; packs with no dependencies all hash alike, which is correct.
+ */
+export function dependencyHash(dependencies: RulePack[]): string {
+	const hash = createHash('sha256');
+	for (const dependency of dependencies) {
+		hash.update(dependency.manifest.name).update('\u0000');
+		hash.update(dependency.body).update('\u0000');
+	}
+	return hash.digest('hex').slice(0, 16);
+}
+
+/** Why a pack is reading everything, for the run report. */
+export type FullReason =
+	| 'incremental-disabled'
+	| 'forced'
+	| 'no-cache'
+	| 'pack-changed'
+	| 'dependency-changed'
+	| 'sha-unreachable';
+
+/** What one pack should read this run. */
+export type PackScanPlan =
+	| {kind: 'full'; reason: FullReason}
+	| {kind: 'partial'; paths: string[]};
+
+/** The repository facts the decision needs, injected so it stays testable. */
+export interface GitProbe {
+	/** The repository's current commit, or null if it cannot be determined. */
+	head(repoDir: string): string | null;
+	/**
+	 * Paths changed between `sha` and the current commit, or null when the diff
+	 * cannot be taken — an unknown commit, a shallow clone, a force-push that
+	 * orphaned it. Null means "cannot tell", which is not the same as "nothing
+	 * changed", and the two must never collapse.
+	 */
+	changedSince(repoDir: string, sha: string): string[] | null;
+}
+
+/** Everything needed to decide one pack's scope. */
+export interface DecideInput {
+	pack: RulePack;
+	repoDir: string;
+	/** This target's cache entry for this pack, if there is one. */
+	cached?: PackCacheEntry;
+	/** The packs this one depends on, already resolved, in prompt order. */
+	dependencies: RulePack[];
+	/** The target opted in to incremental scanning. */
+	incremental: boolean;
+	/** `--full` was passed: audit everything regardless. */
+	forced: boolean;
+	probe: GitProbe;
+}
+
+function full(reason: FullReason): PackScanPlan {
+	return {kind: 'full', reason};
+}
+
+/**
+ * Decide what one pack reads this run.
+ *
+ * A partial plan is only ever returned when the cache names a commit that is
+ * still reachable, the pack is byte-identical to the one that produced it, and
+ * every pack it depends on is too. Anything else reads everything.
+ */
+export function decidePackScope(input: DecideInput): PackScanPlan {
+	if (!input.incremental) {
+		return full('incremental-disabled');
+	}
+	if (input.forced) {
+		return full('forced');
+	}
+	if (!input.cached) {
+		return full('no-cache');
+	}
+	if (
+		input.cached.packVersion !== input.pack.manifest.version ||
+		input.cached.bodyHash !== packBodyHash(input.pack)
+	) {
+		return full('pack-changed');
+	}
+	// A dependency's body is part of this pack's prompt, so an edit to one is an
+	// edit to this pack's question. Without this, changing a shared `rust-general`
+	// pack would leave every dependent still answering the old one against files
+	// it had already decided were unchanged.
+	if (input.cached.dependencyHash !== dependencyHash(input.dependencies)) {
+		return full('dependency-changed');
+	}
+
+	const changed = input.probe.changedSince(input.repoDir, input.cached.sha);
+	if (changed === null) {
+		return full('sha-unreachable');
+	}
+
+	// Narrow the diff to what this pack actually applies to. An empty pattern
+	// list means the whole repository, matching `RepoFiles.read`.
+	const patterns = input.pack.manifest.appliesTo.paths;
+	const paths =
+		patterns.length === 0
+			? changed
+			: changed.filter(path =>
+					patterns.some(pattern => matchesGlob(pattern, path)),
+				);
+	return {kind: 'partial', paths};
+}
+
+/** A human sentence for the run report, so a full pass is never a mystery. */
+export function explainFullReason(reason: FullReason): string {
+	switch (reason) {
+		case 'incremental-disabled':
+			return 'incremental scanning is not enabled for this target';
+		case 'forced':
+			return '--full was passed';
+		case 'no-cache':
+			return 'no cached scan to compare against';
+		case 'pack-changed':
+			return 'the rule pack changed since the last pass';
+		case 'dependency-changed':
+			return 'a pack it depends on changed since the last pass';
+		case 'sha-unreachable':
+			return 'the cached commit is unreachable, so nothing could be diffed';
+	}
+}

--- a/source/incremental/git.ts
+++ b/source/incremental/git.ts
@@ -1,0 +1,48 @@
+/**
+ * The real git probe. The only part of incremental scanning that shells out;
+ * the decision logic takes this as an interface so it stays testable.
+ */
+
+import {spawnSync} from 'node:child_process';
+import type {GitProbe} from './decide.js';
+
+/* c8 ignore start -- spawns git against a real checkout. */
+function git(repoDir: string, args: string[]): string | null {
+	const run = spawnSync('git', ['-C', repoDir, ...args], {
+		encoding: 'utf8',
+		timeout: 30_000,
+	});
+	if (run.error || run.status !== 0) {
+		return null;
+	}
+	return run.stdout.trim();
+}
+
+export const gitProbe: GitProbe = {
+	head(repoDir) {
+		return git(repoDir, ['rev-parse', 'HEAD']);
+	},
+
+	changedSince(repoDir, sha) {
+		// Verify the commit is actually present before diffing. A shallow clone
+		// has the ref but not the object, and `git diff` against a missing commit
+		// fails — which must read as "cannot tell", never as "nothing changed".
+		if (git(repoDir, ['cat-file', '-e', `${sha}^{commit}`]) === null) {
+			return null;
+		}
+		const out = git(repoDir, ['diff', '--name-only', sha, 'HEAD']);
+		if (out === null) {
+			return null;
+		}
+		// Untracked files are changes too: a file added since the last pass and
+		// not yet committed has never been audited, and `git diff` will not
+		// mention it.
+		const untracked =
+			git(repoDir, ['ls-files', '--others', '--exclude-standard']) ?? '';
+		const paths = [...out.split('\n'), ...untracked.split('\n')]
+			.map(line => line.trim())
+			.filter(line => line.length > 0);
+		return [...new Set(paths)];
+	},
+};
+/* c8 ignore stop */

--- a/source/incremental/session.spec.ts
+++ b/source/incremental/session.spec.ts
@@ -1,0 +1,87 @@
+import test from 'ava';
+import type {RulePack} from '../rule-packs/types.js';
+import {lookup} from './cache.js';
+import {dependencyHash, type GitProbe, packBodyHash} from './decide.js';
+import {CacheSession} from './session.js';
+import {emptyCache} from './types.js';
+
+console.log('\nincremental/session.spec.ts');
+
+function pack(name = 'db-safety', body = 'audit'): RulePack {
+	return {
+		manifest: {
+			name,
+			version: '1.2.0',
+			description: '',
+			appliesTo: {paths: ['**/*.ts'], languages: []},
+			severityWeighting: {},
+			dependsOn: [],
+			category: 'security',
+		},
+		body,
+	};
+}
+
+function probe(head: string | null): GitProbe {
+	return {head: () => head, changedSince: () => []};
+}
+
+test('a completed pass records the pack, its hashes and the commit', t => {
+	const session = new CacheSession(emptyCache(), probe('sha-now'));
+	session.recordPass('org/a', '/ws/a', pack(), []);
+
+	const entry = lookup(session.result(), 'org/a', 'db-safety');
+	t.is(entry?.sha, 'sha-now');
+	t.is(entry?.packVersion, '1.2.0');
+	t.is(entry?.bodyHash, packBodyHash(pack()));
+	t.is(entry?.dependencyHash, dependencyHash([]));
+});
+
+test('a repository whose HEAD cannot be read records nothing', t => {
+	// With no commit there is nothing a later run could diff against. Inventing
+	// one would licence skipping files on a boundary that means nothing.
+	const session = new CacheSession(emptyCache(), probe(null));
+	session.recordPass('org/a', '/ws/a', pack(), []);
+	t.deepEqual(session.result(), emptyCache());
+});
+
+test('the cache read at the start is not disturbed by recording', t => {
+	// Decisions for later packs in the same run must be made against the state
+	// the run began with, not against what this run has already written.
+	const session = new CacheSession(emptyCache(), probe('sha-now'));
+	session.recordPass('org/a', '/ws/a', pack(), []);
+	t.is(session.entryFor('org/a', 'db-safety'), undefined);
+	t.not(lookup(session.result(), 'org/a', 'db-safety'), undefined);
+});
+
+test('dependencies are hashed into the entry', t => {
+	const dependency = pack('ts-general', 'shared body');
+	const session = new CacheSession(emptyCache(), probe('sha-now'));
+	session.recordPass('org/a', '/ws/a', pack(), [dependency]);
+	t.is(
+		lookup(session.result(), 'org/a', 'db-safety')?.dependencyHash,
+		dependencyHash([dependency]),
+	);
+});
+
+test('entryFor reads the cache the session was constructed with', t => {
+	const existing = {
+		version: 1,
+		repos: [
+			{
+				repo: 'org/a',
+				packs: [
+					{
+						pack: 'db-safety',
+						packVersion: '1.0.0',
+						bodyHash: 'h',
+						dependencyHash: 'd',
+						sha: 'sha-old',
+					},
+				],
+			},
+		],
+	};
+	const session = new CacheSession(existing, probe('sha-now'));
+	t.is(session.entryFor('org/a', 'db-safety')?.sha, 'sha-old');
+});

--- a/source/incremental/session.ts
+++ b/source/incremental/session.ts
@@ -1,0 +1,65 @@
+/**
+ * One run's view of the incremental cache: what the last pass recorded, and
+ * what this pass should record. The CLI reads the file, hands the contents in,
+ * and writes back whatever the run accumulated.
+ *
+ * A session is only created when a cache path is configured. `runFromConfig`
+ * without one behaves exactly as it did before incremental scanning existed,
+ * which is what keeps `sentinel run` in a plain checkout unchanged.
+ */
+
+import type {RulePack} from '../rule-packs/types.js';
+import {lookup, record} from './cache.js';
+import {dependencyHash, type GitProbe, packBodyHash} from './decide.js';
+import type {IncrementalCache, PackCacheEntry} from './types.js';
+
+/** The mutable per-run cache session. */
+export class CacheSession {
+	/** The cache as it was read, unchanged for the life of the run. */
+	readonly cache: IncrementalCache;
+	readonly probe: GitProbe;
+	private next: IncrementalCache;
+
+	constructor(cache: IncrementalCache, probe: GitProbe) {
+		this.cache = cache;
+		this.probe = probe;
+		this.next = cache;
+	}
+
+	/** The entry the last successful pass left for this repo and pack. */
+	entryFor(repo: string, pack: string): PackCacheEntry | undefined {
+		return lookup(this.cache, repo, pack);
+	}
+
+	/**
+	 * Record that `pack` completed a pass over `repo`.
+	 *
+	 * The commit is read now rather than at the start of the run, and a
+	 * repository whose HEAD cannot be read records nothing at all — with no
+	 * commit there is nothing a later run could diff against, and inventing one
+	 * would licence skipping files on a boundary that means nothing.
+	 */
+	recordPass(
+		repo: string,
+		repoDir: string,
+		pack: RulePack,
+		dependencies: RulePack[],
+	): void {
+		const sha = this.probe.head(repoDir);
+		if (sha === null) {
+			return;
+		}
+		this.next = record(this.next, repo, {
+			pack: pack.manifest.name,
+			packVersion: pack.manifest.version,
+			bodyHash: packBodyHash(pack),
+			dependencyHash: dependencyHash(dependencies),
+			sha,
+		});
+	}
+
+	/** The cache to write back after the run. */
+	result(): IncrementalCache {
+		return this.next;
+	}
+}

--- a/source/incremental/types.ts
+++ b/source/incremental/types.ts
@@ -1,0 +1,56 @@
+/**
+ * The incremental cache: what each pack last audited, and at which commit.
+ *
+ * Committed to the configuration repository beside the run records — the same
+ * posture, and for the same reason. There is no database, no server and no
+ * state anywhere but your own repository, so a cache that cannot be read is a
+ * cache that gets rebuilt by reading everything, never one that silently
+ * narrows an audit.
+ */
+
+/** The cache schema version. Bumped whenever an entry's meaning changes. */
+export const CACHE_VERSION = 1;
+
+/** What one pack had audited on one repository, as of one commit. */
+export interface PackCacheEntry {
+	/** The rule pack's name. */
+	pack: string;
+	/** The pack's manifest version when it last completed a pass. */
+	packVersion: string;
+	/**
+	 * A hash of the pack's audit body. Version alone is not enough: a pack whose
+	 * prompt was edited without a version bump asks a different question, and
+	 * every file has to be re-read to answer it.
+	 */
+	bodyHash: string;
+	/**
+	 * A combined hash of the bodies of every pack this one depends on. A
+	 * dependency's body is part of this pack's prompt, so editing a shared
+	 * `rust-general` pack changes the question every dependent asks — and every
+	 * dependent has to re-read everything to answer it. Kept apart from
+	 * `bodyHash` so the run report can say which of the two actually changed.
+	 */
+	dependencyHash: string;
+	/**
+	 * The commit the repository was at when this pack last completed a pass. The
+	 * next run diffs against it to decide what changed.
+	 */
+	sha: string;
+}
+
+/** Everything cached for one repository. */
+export interface RepoCacheEntry {
+	repo: string;
+	packs: PackCacheEntry[];
+}
+
+/** The whole cache, as committed. */
+export interface IncrementalCache {
+	version: number;
+	repos: RepoCacheEntry[];
+}
+
+/** An empty cache — what a first run, or an unreadable file, starts from. */
+export function emptyCache(): IncrementalCache {
+	return {version: CACHE_VERSION, repos: []};
+}

--- a/source/index.ts
+++ b/source/index.ts
@@ -33,6 +33,7 @@ export {
 	reconcileFindings,
 } from './dedup/reconcile.js';
 export {
+	emptyScope,
 	fullScope,
 	isCompleteScope,
 	issueWasScanned,
@@ -57,6 +58,27 @@ export type {
 	ValidationResult,
 } from './findings/validate.js';
 export {validateFindings} from './findings/validate.js';
+export {
+	lookup as lookupCacheEntry,
+	parseCache,
+	serialiseCache,
+} from './incremental/cache.js';
+export {
+	decidePackScope,
+	dependencyHash,
+	explainFullReason,
+	type FullReason,
+	type GitProbe,
+	type PackScanPlan,
+	packBodyHash,
+} from './incremental/decide.js';
+export {CacheSession} from './incremental/session.js';
+export {
+	CACHE_VERSION,
+	emptyCache,
+	type IncrementalCache,
+	type PackCacheEntry,
+} from './incremental/types.js';
 export {type ParsedInitArgs, parseInitArgs} from './init/args.js';
 export {planInit} from './init/plan.js';
 export {type ScaffoldResult, scaffold} from './init/scaffold.js';

--- a/source/init/scaffold.spec.ts
+++ b/source/init/scaffold.spec.ts
@@ -81,3 +81,20 @@ test('force overwrites existing files', t => {
 		rmSync(dir, {recursive: true, force: true});
 	}
 });
+
+test('the scaffolded workflow commits the incremental cache', t => {
+	// Without this the cache is written and thrown away on the next checkout, so
+	// every scheduled run finds no cache and re-reads everything — incremental
+	// scanning would look enabled and quietly do nothing.
+	const dir = freshDir();
+	try {
+		scaffold(OPTIONS, dir);
+		const workflow = readFileSync(
+			join(dir, '.github/workflows/sentinel.yml'),
+			'utf8',
+		);
+		t.true(workflow.includes('.sentinel-cache.json'));
+	} finally {
+		rmSync(dir, {recursive: true, force: true});
+	}
+});

--- a/source/init/templates.ts
+++ b/source/init/templates.ts
@@ -93,11 +93,15 @@ jobs:
           --output "$GITHUB_STEP_SUMMARY"
           \${{ github.event.inputs.dry_run == 'true' && '--dry-run' || '' }}
 
-      - name: Commit run record and dashboard
+      - name: Commit run record, dashboard and incremental cache
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add runs dashboard
+          # The incremental cache has to survive between runs or every run finds
+          # no cache and re-reads everything — incremental scanning would look
+          # enabled and do nothing. Tolerated when absent: a dry run writes none.
+          git add .sentinel-cache.json || true
           if ! git diff --cached --quiet; then
             git commit -m "chore: sentinel run record [skip ci]"
             git push
@@ -209,6 +213,7 @@ the example block and set its key as an environment variable / Actions secret.
 - \`rule-packs/\` — your rule packs (you author these).
 - \`.github/workflows/sentinel.yml\` — the scheduled audit.
 - \`runs/\` — a committed JSON record per run (the durable history).
+- \`.sentinel-cache.json\` — what each pack last audited, for incremental runs.
 - \`dashboard/\` — a generated static \`index.html\`; serve it via GitHub Pages.
 `;
 }

--- a/source/observe/dashboard.spec.ts
+++ b/source/observe/dashboard.spec.ts
@@ -237,3 +237,25 @@ test('a record written before packLoadErrors existed still renders', t => {
 	t.true(html.includes('<!doctype html>'));
 	t.false(html.includes('did not complete'));
 });
+
+test('the dashboard surfaces packs that re-read everything', t => {
+	const html = renderDashboard([
+		record({
+			repos: [
+				{
+					repo: 'org/a',
+					findings: 0,
+					bySeverity: {low: 0, medium: 0, high: 0, critical: 0},
+					packs: [],
+					fullPasses: ['db-safety — the cached commit is unreachable'],
+				},
+			],
+		}),
+	]);
+	t.true(html.includes('re-read every file'));
+	t.true(html.includes('db-safety'));
+});
+
+test('a run with no full passes gets no notice', t => {
+	t.false(renderDashboard([record()]).includes('re-read every file'));
+});

--- a/source/observe/dashboard.ts
+++ b/source/observe/dashboard.ts
@@ -42,6 +42,18 @@ function problemsOf(record: RunRecord): string[] {
 	return [...(record.packLoadErrors ?? []), ...record.targetErrors];
 }
 
+/**
+ * Packs that re-read everything on a target that asked for incremental
+ * scanning. Not a problem — the audit was complete, which is the safe outcome —
+ * but the operator's only durable signal that the setting they enabled is not
+ * doing anything, so it is shown rather than left to an expired step summary.
+ */
+function fullPassesOf(record: RunRecord): string[] {
+	return record.repos.flatMap(repo =>
+		(repo.fullPasses ?? []).map(note => `${repo.repo}: ${note}`),
+	);
+}
+
 function problemCell(record: RunRecord): string {
 	const count = problemsOf(record).length;
 	return count > 0
@@ -101,6 +113,14 @@ export function renderDashboard(records: RunRecord[]): string {
 		? `Latest run ${escapeHtml(latest.timestamp)} — ${latest.totals.findings} finding(s) across ${latest.totals.repos} repo(s).`
 		: 'No runs recorded yet.';
 	const banner = problemBanner(latest);
+	const fullPasses = latest ? fullPassesOf(latest) : [];
+	const fullPassNotice =
+		fullPasses.length === 0
+			? ''
+			: `<div class="notice">
+<strong>Incremental scanning: ${fullPasses.length} pack pass(es) re-read every file.</strong> The audit was complete — this is the safe outcome — but the setting is not saving anything for these.
+<ul>${fullPasses.map(note => `<li>${escapeHtml(note)}</li>`).join('')}</ul>
+</div>`;
 
 	return `<!doctype html>
 <html lang="en">
@@ -114,6 +134,8 @@ body { font-family: system-ui, sans-serif; background: #1a1b26; color: #a9b1d6; 
 h1 { color: #7aa2f7; margin: 0 0 .25rem; font-size: 1.4rem; }
 p.summary { color: #c0caf5; margin: 0 0 1.5rem; }
 div.scroll { overflow-x: auto; }
+div.notice { background: #232433; border-left: 3px solid #7dcfff; padding: .75rem 1rem; margin: 0 0 1.5rem; border-radius: 4px; color: #c0caf5; }
+div.notice ul { margin: .5rem 0 0; padding-left: 1.2rem; }
 table { border-collapse: collapse; width: 100%; font-size: .9rem; }
 th, td { padding: .5rem .6rem; text-align: left; white-space: nowrap; border-bottom: 1px solid #292e42; }
 th { color: #565f89; font-weight: 600; text-transform: uppercase; font-size: .72rem; letter-spacing: .04em; }
@@ -136,7 +158,7 @@ footer { margin-top: 1.5rem; color: #565f89; font-size: .8rem; }
 <body>
 <h1>🛡️ Sentinel</h1>
 <p class="summary">${summary}</p>
-${banner}
+${banner}${fullPassNotice}
 <div class="scroll">
 <table>
 <thead><tr>

--- a/source/observe/record.spec.ts
+++ b/source/observe/record.spec.ts
@@ -286,3 +286,49 @@ test('held issues are carried into the durable record', t => {
 	);
 	t.is(record.filing?.held, 5, 'summed across repos');
 });
+
+test('full-pass reasons reach the durable record', t => {
+	// The run report is an Actions step summary that expires. An operator asking
+	// a week later why a run did a full read needs it in the record, which is
+	// also their only signal that incremental scanning is not saving anything.
+	const record = buildRunRecord(
+		report({
+			outcome: {
+				repos: [
+					{
+						repo: 'org/a',
+						packs: [pack([])],
+						missingPacks: [],
+						unresolvedPacks: [],
+						fullPasses: [{pack: 'db-safety', reason: 'sha-unreachable'}],
+					},
+				],
+			},
+		}),
+		'2026-07-21T06:00:00.000Z',
+		'live',
+	);
+	t.is(record.repos[0]?.fullPasses?.length, 1);
+	t.true(record.repos[0]?.fullPasses?.[0]?.includes('db-safety'));
+	t.true(record.repos[0]?.fullPasses?.[0]?.includes('unreachable'));
+});
+
+test('a repo with no full passes writes no key', t => {
+	const built = buildRunRecord(
+		report({
+			outcome: {
+				repos: [
+					{
+						repo: 'org/a',
+						packs: [pack([])],
+						missingPacks: [],
+						unresolvedPacks: [],
+					},
+				],
+			},
+		}),
+		'2026-07-21T06:00:00.000Z',
+		'audit-only',
+	);
+	t.is(built.repos[0]?.fullPasses, undefined);
+});

--- a/source/observe/record.ts
+++ b/source/observe/record.ts
@@ -4,6 +4,7 @@
  */
 
 import {SEVERITIES, type Severity} from '../findings/types.js';
+import {explainFullReason} from '../incremental/decide.js';
 import type {RunReport} from '../run/run.js';
 import type {RepoOutcome} from '../run/types.js';
 import type {
@@ -40,7 +41,18 @@ function repoRecord(outcome: RepoOutcome): RepoRunRecord {
 			ok: pack.ok,
 		};
 	});
-	return {repo: outcome.repo, findings, bySeverity, packs};
+	const record: RepoRunRecord = {
+		repo: outcome.repo,
+		findings,
+		bySeverity,
+		packs,
+	};
+	if (outcome.fullPasses && outcome.fullPasses.length > 0) {
+		record.fullPasses = outcome.fullPasses.map(
+			note => `${note.pack} — ${explainFullReason(note.reason)}`,
+		);
+	}
+	return record;
 }
 
 /** Build a run record from a report, a timestamp, and the run mode. */

--- a/source/observe/types.ts
+++ b/source/observe/types.ts
@@ -24,6 +24,18 @@ export interface RepoRunRecord {
 	findings: number;
 	bySeverity: SeverityCounts;
 	packs: PackRunRecord[];
+	/**
+	 * Packs that re-read every file on a target that asked for incremental
+	 * scanning, as `pack — reason` lines.
+	 *
+	 * In the durable record and not only the run report, because the report is
+	 * an Actions step summary that expires. An operator who enabled incremental
+	 * scanning, opened the dashboard a week later and asked why a run did a full
+	 * read would otherwise have nowhere to look — and this is their only signal
+	 * that the setting they turned on is not doing anything. Same reason
+	 * `packLoadErrors` is on the record rather than only in the console.
+	 */
+	fullPasses?: string[];
 }
 
 /** The mode a run executed in. */

--- a/source/run/audit.ts
+++ b/source/run/audit.ts
@@ -73,3 +73,26 @@ export async function auditPack(
 		},
 	};
 }
+
+/**
+ * The outcome of a pack that had nothing to audit — an incremental pass in
+ * which no file the pack applies to changed.
+ *
+ * Deliberately not a model call with an empty file list. Beyond the wasted
+ * request, asking a model to audit nothing invites it to answer with something.
+ * It counts as `ok`: the pack ran to completion and found nothing, which is a
+ * different claim from a pass that errored, and the cache may only advance on
+ * the former.
+ */
+export function skippedPackOutcome(pack: RulePack): PackOutcome {
+	return {
+		pack: pack.manifest.name,
+		version: pack.manifest.version,
+		findings: [],
+		severityOverrides: [],
+		attempts: 0,
+		ok: true,
+		errors: [],
+		usage: {durationMs: 0, promptTokens: 0, outputTokens: 0},
+	};
+}

--- a/source/run/expand.spec.ts
+++ b/source/run/expand.spec.ts
@@ -20,7 +20,9 @@ function lister(
 test('passes explicit repo targets through', async t => {
 	const targets: Target[] = [{repo: 'my-org/a', rulePacks: ['p']}];
 	const result = await expandTargets(targets);
-	t.deepEqual(result.targets, [{repo: 'my-org/a', rulePacks: ['p']}]);
+	t.deepEqual(result.targets, [
+		{repo: 'my-org/a', rulePacks: ['p'], incremental: false},
+	]);
 	t.deepEqual(result.errors, []);
 });
 
@@ -80,4 +82,32 @@ test('records an error when listing fails', async t => {
 	);
 	t.is(result.targets.length, 0);
 	t.true(result.errors[0]?.includes('gh auth expired'));
+});
+
+test('a target opting in to incremental carries the flag through', async t => {
+	const result = await expandTargets([
+		{repo: 'my-org/a', rulePacks: ['p'], incremental: true},
+	]);
+	t.true(result.targets[0]?.incremental);
+});
+
+test('one target wanting a full read wins over another opting in', async t => {
+	// A repo can match several targets. Taking the union of their packs but the
+	// OR of their flags would let an unrelated pattern silently cause a target's
+	// files to be skipped, so the merge is an AND.
+	const result = await expandTargets([
+		{repo: 'my-org/a', rulePacks: ['p'], incremental: true},
+		{repo: 'my-org/a', rulePacks: ['q']},
+	]);
+	t.is(result.targets.length, 1);
+	t.deepEqual(result.targets[0]?.rulePacks, ['p', 'q'], 'packs still union');
+	t.false(result.targets[0]?.incremental, 'but the flag does not');
+});
+
+test('the AND holds regardless of the order the targets appear in', async t => {
+	const result = await expandTargets([
+		{repo: 'my-org/a', rulePacks: ['q']},
+		{repo: 'my-org/a', rulePacks: ['p'], incremental: true},
+	]);
+	t.false(result.targets[0]?.incremental);
 });

--- a/source/run/expand.ts
+++ b/source/run/expand.ts
@@ -13,6 +13,13 @@ import type {RepoLister} from './repo-lister.js';
 export interface ResolvedRepoTarget {
 	repo: string;
 	rulePacks: string[];
+	/**
+	 * True only when *every* target that contributed to this repo asked for
+	 * incremental scanning. A repo can match several targets, and one of them
+	 * expecting a complete re-read has to win — the alternative is a target
+	 * silently having its files skipped because an unrelated pattern opted in.
+	 */
+	incremental: boolean;
 }
 
 /** The outcome of expanding targets. */
@@ -22,16 +29,27 @@ export interface ExpandResult {
 	errors: string[];
 }
 
+interface Accumulated {
+	packs: Set<string>;
+	incremental: boolean;
+}
+
 function addRepo(
-	byRepo: Map<string, Set<string>>,
+	byRepo: Map<string, Accumulated>,
 	repo: string,
-	rulePacks: string[],
+	target: Target,
 ): void {
-	const packs = byRepo.get(repo) ?? new Set<string>();
-	for (const pack of rulePacks) {
+	const existing = byRepo.get(repo);
+	const packs = existing?.packs ?? new Set<string>();
+	for (const pack of target.rulePacks) {
 		packs.add(pack);
 	}
-	byRepo.set(repo, packs);
+	const incremental = target.incremental === true;
+	byRepo.set(repo, {
+		packs,
+		// AND, not OR: every contributing target must have opted in.
+		incremental: existing ? existing.incremental && incremental : incremental,
+	});
 }
 
 /**
@@ -43,13 +61,13 @@ export async function expandTargets(
 	targets: Target[],
 	lister?: RepoLister,
 ): Promise<ExpandResult> {
-	const byRepo = new Map<string, Set<string>>();
+	const byRepo = new Map<string, Accumulated>();
 	const errors: string[] = [];
 	const listed = new Map<string, string[]>();
 
 	for (const target of targets) {
 		if (target.repo) {
-			addRepo(byRepo, target.repo, target.rulePacks);
+			addRepo(byRepo, target.repo, target);
 			continue;
 		}
 		if (!target.pattern) {
@@ -84,12 +102,16 @@ export async function expandTargets(
 
 		const matched = repos.filter(repo => matchesGlob(pattern, repo));
 		for (const repo of matched) {
-			addRepo(byRepo, repo, target.rulePacks);
+			addRepo(byRepo, repo, target);
 		}
 	}
 
 	const resolved: ResolvedRepoTarget[] = [...byRepo.entries()].map(
-		([repo, packs]) => ({repo, rulePacks: [...packs]}),
+		([repo, {packs, incremental}]) => ({
+			repo,
+			rulePacks: [...packs],
+			incremental,
+		}),
 	);
 	return {targets: resolved, errors};
 }

--- a/source/run/report.spec.ts
+++ b/source/run/report.spec.ts
@@ -378,3 +378,32 @@ test('a pack that overrode nothing adds no note', t => {
 	};
 	t.false(renderReport(run).includes('severity weighting overrode'));
 });
+
+test('a pack that re-read everything on an incremental target says why', t => {
+	// An operator who switched incremental on and saw no speed-up needs this
+	// said out loud. Silently doing the slow thing is how a setting gets
+	// believed to be broken.
+	const run: RunOutcome = {
+		repos: [
+			{
+				repo: 'org/a',
+				packs: [pack()],
+				missingPacks: [],
+				unresolvedPacks: [],
+				fullPasses: [{pack: 'db-safety', reason: 'sha-unreachable'}],
+			},
+		],
+	};
+	const markdown = renderReport(run);
+	t.true(markdown.includes('db-safety'));
+	t.true(markdown.includes('cached commit is unreachable'));
+});
+
+test('a repo with no full-pass notes gets no note', t => {
+	const run: RunOutcome = {
+		repos: [
+			{repo: 'org/a', packs: [pack()], missingPacks: [], unresolvedPacks: []},
+		],
+	};
+	t.false(renderReport(run).includes('re-read every file'));
+});

--- a/source/run/report.ts
+++ b/source/run/report.ts
@@ -7,7 +7,9 @@ import {findingHash} from '../dedup/hash.js';
 import type {ReconcileResult} from '../dedup/reconcile.js';
 import type {Finding} from '../findings/types.js';
 import type {SeverityOverride} from '../findings/weighting.js';
+import {explainFullReason} from '../incremental/decide.js';
 import type {
+	FullPassNote,
 	PackLoadError,
 	PackOutcome,
 	RepoOutcome,
@@ -111,6 +113,25 @@ export function renderPackSelectionProblems(
 	return parts;
 }
 
+/**
+ * Why a pack read everything on a target that asked for incremental scanning.
+ * An operator who turned it on and saw no speed-up needs this said out loud;
+ * silently doing the slow thing is how a setting gets believed to be broken.
+ */
+function fullPassNote(notes: FullPassNote[] | undefined): string[] {
+	if (!notes || notes.length === 0) {
+		return [];
+	}
+	return [
+		[
+			`> ${notes.length} pack(s) re-read every file despite incremental scanning:`,
+			...notes.map(
+				note => `> - \`${note.pack}\`: ${explainFullReason(note.reason)}`,
+			),
+		].join('\n'),
+	];
+}
+
 function repoSection(outcome: RepoOutcome): string {
 	const parts = [
 		`## ${outcome.repo}`,
@@ -118,6 +139,7 @@ function repoSection(outcome: RepoOutcome): string {
 			outcome.missingPacks,
 			outcome.unresolvedPacks,
 		),
+		...fullPassNote(outcome.fullPasses),
 	];
 	for (const pack of outcome.packs) {
 		parts.push(packSection(pack));

--- a/source/run/run.spec.ts
+++ b/source/run/run.spec.ts
@@ -810,3 +810,114 @@ test('an incremental run holds the issues whose files it skipped', async t => {
 	t.is(result?.incremented, 0, 'not aged');
 	t.is(result?.resolved, 0, 'and not closed, even at a threshold of 1');
 });
+
+test('a pack with nothing changed reads nothing and calls no model', async t => {
+	// The bug this guards: `RepoFiles.read` treats an empty pattern list as "the
+	// whole repository", so a pack with nothing to re-read would read everything
+	// and then record a scope claiming it had — incremental scanning becoming a
+	// silent no-op on the commonest case of all.
+	const all = [
+		{path: 'src/a.ts', content: 'a'},
+		{path: 'src/b.ts', content: 'b'},
+	];
+	const first = cacheSession([], 'sha-1');
+	await runFromConfig(
+		INCREMENTAL_CONFIG,
+		{
+			runner: findingRunner(),
+			files: recordingFiles(all).files,
+			packs: packLoader({packs: [pack('p')], errors: []}),
+			cache: first,
+			now: NOW,
+		},
+		OPTIONS,
+	);
+
+	const {files, reads} = recordingFiles(all);
+	let modelCalls = 0;
+	const report = await runFromConfig(
+		INCREMENTAL_CONFIG,
+		{
+			runner: {
+				async run(): Promise<ModelRunResult> {
+					modelCalls++;
+					return {ok: true, output: JSON.stringify([FINDING])};
+				},
+			},
+			files,
+			packs: packLoader({packs: [pack('p')], errors: []}),
+			cache: new CacheSession(first.result(), {
+				head: () => 'sha-2',
+				changedSince: () => [],
+			}),
+			now: NOW,
+		},
+		OPTIONS,
+	);
+
+	t.deepEqual(reads, [], 'no read at all');
+	t.is(modelCalls, 0, 'and no model call');
+	t.is(report.outcome.repos[0]?.packs[0]?.findings.length, 0);
+	t.true(report.outcome.repos[0]?.packs[0]?.ok, 'the pass completed');
+});
+
+test('a pack that scanned nothing holds every one of its issues', async t => {
+	// The other half of the same bug. If the empty read had returned the whole
+	// repo, the scope would claim every file was scanned and nothing would be
+	// held — so an unchanged repo would age out its own open findings.
+	const all = [{path: 'src/a.ts', content: 'a'}];
+	const first = cacheSession([], 'sha-1');
+	const {client: firstClient, created} = fakeClient();
+	await runFromConfig(
+		INCREMENTAL_CONFIG,
+		{
+			runner: findingRunner(),
+			files: recordingFiles(all).files,
+			packs: packLoader({packs: [pack('p')], errors: []}),
+			client: firstClient,
+			cache: first,
+			now: NOW,
+		},
+		OPTIONS,
+	);
+
+	const existing: ExistingIssue[] = [
+		{
+			number: 1,
+			url: 'u',
+			state: 'open',
+			labels: ['sentinel'],
+			body: created[0]?.body ?? '',
+		},
+	];
+	const client: ReconcileClient = {
+		async ensureLabels(): Promise<LabelFailure[]> {
+			return [];
+		},
+		async createIssue(): Promise<CreatedIssue> {
+			return {number: 2, url: 'u'};
+		},
+		async listIssues(): Promise<ExistingIssue[]> {
+			return existing;
+		},
+		async updateIssue(): Promise<void> {},
+		async closeIssue(): Promise<void> {},
+	};
+	const report = await runFromConfig(
+		INCREMENTAL_CONFIG,
+		{
+			runner: findingRunner(),
+			files: recordingFiles(all).files,
+			packs: packLoader({packs: [pack('p')], errors: []}),
+			client,
+			cache: new CacheSession(first.result(), {
+				head: () => 'sha-2',
+				changedSince: () => [],
+			}),
+			now: NOW,
+		},
+		{...OPTIONS, resolveAfterMisses: 1},
+	);
+	t.is(report.reconciled[0]?.result.held, 1);
+	t.is(report.reconciled[0]?.result.resolved, 0);
+});

--- a/source/run/run.spec.ts
+++ b/source/run/run.spec.ts
@@ -1,6 +1,9 @@
 import test from 'ava';
 import type {SentinelConfig} from '../config/types.js';
 import {readMarker} from '../dedup/markers.js';
+import {lookup} from '../incremental/cache.js';
+import {CacheSession} from '../incremental/session.js';
+import {emptyCache} from '../incremental/types.js';
 import type {
 	CreatedIssue,
 	CreateIssueParams,
@@ -10,6 +13,7 @@ import type {
 } from '../issues/types.js';
 import type {ModelRunner, ModelRunResult} from '../orchestrator/types.js';
 import type {SourceFile} from '../prompt/types.js';
+import {matchesGlob} from '../rule-packs/glob.js';
 import type {RulePack} from '../rule-packs/types.js';
 import {runFromConfig, runLocal} from './run.js';
 import type {LoadedPacks, PackLoader, RepoFiles} from './types.js';
@@ -532,4 +536,277 @@ test('a config-driven run holds nothing, because it reads everything', async t =
 		OPTIONS,
 	);
 	t.is(report.reconciled[0]?.result.held, 0);
+});
+
+/** RepoFiles that serve a fixed file list and record every read's patterns. */
+function recordingFiles(files: SourceFile[]) {
+	const reads: string[][] = [];
+	const repoFilesImpl: RepoFiles = {
+		async read(_dir, patterns): Promise<SourceFile[]> {
+			reads.push(patterns);
+			return files.filter(
+				file =>
+					patterns.length === 0 ||
+					patterns.some(pattern => matchesGlob(pattern, file.path)),
+			);
+		},
+		async readText(): Promise<string | null> {
+			return null;
+		},
+	};
+	return {files: repoFilesImpl, reads};
+}
+
+function cacheSession(changed: string[] | null, head = 'sha-new') {
+	return new CacheSession(emptyCache(), {
+		head: () => head,
+		changedSince: () => changed,
+	});
+}
+
+const INCREMENTAL_CONFIG = config({
+	targets: [{repo: 'my-org/a', rulePacks: ['p'], incremental: true}],
+});
+
+test('the first run has no cache, so it reads everything', async t => {
+	const {files, reads} = recordingFiles([
+		{path: 'src/a.ts', content: 'a'},
+		{path: 'src/b.ts', content: 'b'},
+	]);
+	const cache = cacheSession([]);
+	const report = await runFromConfig(
+		INCREMENTAL_CONFIG,
+		{
+			runner: findingRunner(),
+			files,
+			packs: packLoader({packs: [pack('p')], errors: []}),
+			cache,
+			now: NOW,
+		},
+		OPTIONS,
+	);
+	t.deepEqual(reads, [['src/**/*.ts']], 'one union read of the pack patterns');
+	t.is(report.outcome.repos[0]?.packs[0]?.findings.length, 1);
+});
+
+test('a completed pass records the commit for next time', async t => {
+	const {files} = recordingFiles([{path: 'src/a.ts', content: 'a'}]);
+	const cache = cacheSession([]);
+	await runFromConfig(
+		INCREMENTAL_CONFIG,
+		{
+			runner: findingRunner(),
+			files,
+			packs: packLoader({packs: [pack('p')], errors: []}),
+			cache,
+			now: NOW,
+		},
+		OPTIONS,
+	);
+	t.is(lookup(cache.result(), 'my-org/a', 'p')?.sha, 'sha-new');
+});
+
+test('a pack whose audit failed records nothing', async t => {
+	// Recording a commit for a pass that errored would let the next run skip
+	// files on the strength of an audit that never happened.
+	const {files} = recordingFiles([{path: 'src/a.ts', content: 'a'}]);
+	const cache = cacheSession([]);
+	await runFromConfig(
+		INCREMENTAL_CONFIG,
+		{
+			runner: {
+				async run(): Promise<ModelRunResult> {
+					return {ok: false, output: '', error: 'model exploded'};
+				},
+			},
+			files,
+			packs: packLoader({packs: [pack('p')], errors: []}),
+			cache,
+			now: NOW,
+		},
+		OPTIONS,
+	);
+	t.is(lookup(cache.result(), 'my-org/a', 'p'), undefined);
+});
+
+test('a second run reads only what changed, and holds nothing it did read', async t => {
+	const all = [
+		{path: 'src/a.ts', content: 'a'},
+		{path: 'src/b.ts', content: 'b'},
+	];
+	// Seed the cache as a completed first pass would have left it.
+	const first = cacheSession([], 'sha-1');
+	await runFromConfig(
+		INCREMENTAL_CONFIG,
+		{
+			runner: findingRunner(),
+			files: recordingFiles(all).files,
+			packs: packLoader({packs: [pack('p')], errors: []}),
+			cache: first,
+			now: NOW,
+		},
+		OPTIONS,
+	);
+
+	const {files, reads} = recordingFiles(all);
+	const second = new CacheSession(first.result(), {
+		head: () => 'sha-2',
+		changedSince: () => ['src/b.ts'],
+	});
+	await runFromConfig(
+		INCREMENTAL_CONFIG,
+		{
+			runner: findingRunner(),
+			files,
+			packs: packLoader({packs: [pack('p')], errors: []}),
+			cache: second,
+			now: NOW,
+		},
+		OPTIONS,
+	);
+	t.deepEqual(reads, [['src/b.ts']], 'only the changed file is read');
+});
+
+test('a target that did not opt in is never incremental', async t => {
+	const all = [
+		{path: 'src/a.ts', content: 'a'},
+		{path: 'src/b.ts', content: 'b'},
+	];
+	const first = cacheSession([], 'sha-1');
+	await runFromConfig(
+		config(),
+		{
+			runner: findingRunner(),
+			files: recordingFiles(all).files,
+			packs: packLoader({packs: [pack('p')], errors: []}),
+			cache: first,
+			now: NOW,
+		},
+		OPTIONS,
+	);
+
+	const {files, reads} = recordingFiles(all);
+	await runFromConfig(
+		config(),
+		{
+			runner: findingRunner(),
+			files,
+			packs: packLoader({packs: [pack('p')], errors: []}),
+			cache: new CacheSession(first.result(), {
+				head: () => 'sha-2',
+				changedSince: () => ['src/b.ts'],
+			}),
+			now: NOW,
+		},
+		OPTIONS,
+	);
+	t.deepEqual(reads, [['src/**/*.ts']], 'still a full union read');
+});
+
+test('--full overrides a warm cache', async t => {
+	const all = [{path: 'src/a.ts', content: 'a'}];
+	const first = cacheSession([], 'sha-1');
+	await runFromConfig(
+		INCREMENTAL_CONFIG,
+		{
+			runner: findingRunner(),
+			files: recordingFiles(all).files,
+			packs: packLoader({packs: [pack('p')], errors: []}),
+			cache: first,
+			now: NOW,
+		},
+		OPTIONS,
+	);
+
+	const {files, reads} = recordingFiles(all);
+	await runFromConfig(
+		INCREMENTAL_CONFIG,
+		{
+			runner: findingRunner(),
+			files,
+			packs: packLoader({packs: [pack('p')], errors: []}),
+			cache: new CacheSession(first.result(), {
+				head: () => 'sha-2',
+				changedSince: () => [],
+			}),
+			now: NOW,
+		},
+		{...OPTIONS, full: true},
+	);
+	t.deepEqual(reads, [['src/**/*.ts']]);
+});
+
+test('an incremental run holds the issues whose files it skipped', async t => {
+	// The acceptance property, end to end: a repo audited incrementally, an open
+	// issue against a file this run did not read, and no ageing of that issue.
+	const all = [
+		{path: 'src/a.ts', content: 'a'},
+		{path: 'src/b.ts', content: 'b'},
+	];
+	const first = cacheSession([], 'sha-1');
+	const {client: firstClient, created} = fakeClient();
+	await runFromConfig(
+		INCREMENTAL_CONFIG,
+		{
+			runner: findingRunner(),
+			files: recordingFiles(all).files,
+			packs: packLoader({packs: [pack('p')], errors: []}),
+			client: firstClient,
+			cache: first,
+			now: NOW,
+		},
+		OPTIONS,
+	);
+	const filed = created[0];
+	t.truthy(filed, 'the first run filed an issue');
+	t.is(readMarker(filed?.body ?? '', 'pack'), 'p');
+
+	// Second run: the finding's file is unchanged, so the pack never reads it.
+	// The finding is therefore absent — and must not be read as fixed.
+	const existing: ExistingIssue[] = [
+		{
+			number: 1,
+			url: 'u',
+			state: 'open',
+			labels: ['sentinel'],
+			body: filed?.body ?? '',
+		},
+	];
+	const secondClient: ReconcileClient = {
+		async ensureLabels(): Promise<LabelFailure[]> {
+			return [];
+		},
+		async createIssue(): Promise<CreatedIssue> {
+			return {number: 2, url: 'u'};
+		},
+		async listIssues(): Promise<ExistingIssue[]> {
+			return existing;
+		},
+		async updateIssue(): Promise<void> {},
+		async closeIssue(): Promise<void> {},
+	};
+	const report = await runFromConfig(
+		INCREMENTAL_CONFIG,
+		{
+			runner: {
+				async run(): Promise<ModelRunResult> {
+					return {ok: true, output: '[]'};
+				},
+			},
+			files: recordingFiles(all).files,
+			packs: packLoader({packs: [pack('p')], errors: []}),
+			client: secondClient,
+			cache: new CacheSession(first.result(), {
+				head: () => 'sha-2',
+				changedSince: () => ['src/other.ts'],
+			}),
+			now: NOW,
+		},
+		{...OPTIONS, resolveAfterMisses: 1},
+	);
+
+	const result = report.reconciled[0]?.result;
+	t.is(result?.held, 1, 'held');
+	t.is(result?.incremented, 0, 'not aged');
+	t.is(result?.resolved, 0, 'and not closed, even at a threshold of 1');
 });

--- a/source/run/run.ts
+++ b/source/run/run.ts
@@ -184,7 +184,11 @@ export async function runFromConfig(
 		// files reads only what it needs. Packs reading everything still share a
 		// single union read, exactly as before.
 		const plans = new Map<string, PackScanPlan>();
+		// Resolved once per pack and shared by the planning and recording steps,
+		// rather than re-walking the dependency graph for each.
+		const dependencies = new Map<string, RulePack[]>();
 		for (const pack of resolvedPacks) {
+			dependencies.set(pack.manifest.name, dependenciesOf(resolvedPacks, pack));
 			plans.set(
 				pack.manifest.name,
 				deps.cache
@@ -192,12 +196,18 @@ export async function runFromConfig(
 							pack,
 							repoDir,
 							cached: deps.cache.entryFor(repoName, pack.manifest.name),
-							dependencies: dependenciesOf(resolvedPacks, pack),
+							dependencies: dependencies.get(pack.manifest.name) ?? [],
 							incremental: target.incremental,
 							forced: options.full === true,
 							probe: deps.cache.probe,
 						})
-					: {kind: 'full', reason: 'incremental-disabled'},
+					: {
+							kind: 'full',
+							// Without a cache session there is nothing to compare against.
+							// Saying "not enabled for this target" would contradict a
+							// config that did enable it.
+							reason: target.incremental ? 'no-cache' : 'incremental-disabled',
+						},
 			);
 		}
 
@@ -251,7 +261,7 @@ export async function runFromConfig(
 					repoName,
 					repoDir,
 					pack,
-					dependenciesOf(resolvedPacks, pack),
+					dependencies.get(pack.manifest.name) ?? [],
 				);
 			}
 		}

--- a/source/run/run.ts
+++ b/source/run/run.ts
@@ -12,13 +12,21 @@ import {join} from 'node:path';
 import {parseRepoOverride} from '../config/repo-override.js';
 import type {RepoOverride, SentinelConfig} from '../config/types.js';
 import {type ReconcileResult, reconcileFindings} from '../dedup/reconcile.js';
-import {fullScope} from '../dedup/scope.js';
+import {emptyScope} from '../dedup/scope.js';
 import type {Finding} from '../findings/types.js';
+import {
+	decidePackScope,
+	type FullReason,
+	type PackScanPlan,
+} from '../incremental/decide.js';
+import type {CacheSession} from '../incremental/session.js';
 import {targetRepoFor} from '../issues/file.js';
 import type {FilingContext, ReconcileClient} from '../issues/types.js';
 import type {AutoFixOptions} from '../orchestrator/auto-fix.js';
 import type {ModelRunner} from '../orchestrator/types.js';
+import {resolveDependencies} from '../rule-packs/dependencies.js';
 import {parseRulePack} from '../rule-packs/parse.js';
+import type {RulePack} from '../rule-packs/types.js';
 import {auditPack} from './audit.js';
 import type {PrepareResult} from './clone.js';
 import {expandTargets} from './expand.js';
@@ -30,6 +38,7 @@ import {
 import type {RepoLister} from './repo-lister.js';
 import {selectPacks, unionPatterns} from './select.js';
 import type {
+	FullPassNote,
 	PackLoadError,
 	PackLoader,
 	PackOutcome,
@@ -49,6 +58,11 @@ export interface RunDeps {
 	repoLister?: RepoLister;
 	/** Ensures a target repo is checked out; omit to assume repos are present. */
 	cloneRepo?: (repo: string, dir: string) => Promise<PrepareResult>;
+	/**
+	 * The incremental cache for this run. Omit it and every pack reads
+	 * everything, which is the pre-incremental behaviour and the default.
+	 */
+	cache?: CacheSession;
 	/** ISO timestamp for deterministic reconciliation. */
 	now: string;
 }
@@ -70,6 +84,8 @@ export interface RunConfigOptions {
 	dryRun?: boolean;
 	autoFix?: AutoFixOptions;
 	resolveAfterMisses?: number;
+	/** Re-audit everything, ignoring the cache. */
+	full?: boolean;
 }
 
 /** Everything a config-driven run produced. */
@@ -84,6 +100,28 @@ export interface RunReport {
 	targetErrors: string[];
 	/** True if issues were filed (client present and not a dry run). */
 	filed: boolean;
+}
+
+/**
+ * The packs one pack depends on, transitively, in the order the resolver puts
+ * them in the prompt. The root is dropped: a pack is not its own dependency,
+ * and folding it in would make `dependencyHash` shadow `bodyHash` and lose the
+ * distinction the run report draws between the two.
+ */
+function dependenciesOf(available: RulePack[], pack: RulePack): RulePack[] {
+	const chain = resolveDependencies(available, pack.manifest.name);
+	const byName = new Map(available.map(entry => [entry.manifest.name, entry]));
+	const dependencies: RulePack[] = [];
+	for (const name of chain.order) {
+		if (name === pack.manifest.name) {
+			continue;
+		}
+		const dependency = byName.get(name);
+		if (dependency) {
+			dependencies.push(dependency);
+		}
+	}
+	return dependencies;
 }
 
 async function readOverride(
@@ -136,31 +174,95 @@ export async function runFromConfig(
 			unresolved: unresolvedPacks,
 		} = selectPacks(loaded.packs, target.rulePacks);
 
-		const files = await deps.files.read(repoDir, unionPatterns(resolvedPacks));
-
 		const runnerOptions: AutoFixOptions = {
 			...options.autoFix,
 			cwd: repoDir,
 			configDir: options.configDir,
 		};
-		const packOutcomes: PackOutcome[] = [];
+
+		// Decide each pack's scope before reading anything, so a pack that may skip
+		// files reads only what it needs. Packs reading everything still share a
+		// single union read, exactly as before.
+		const plans = new Map<string, PackScanPlan>();
 		for (const pack of resolvedPacks) {
-			packOutcomes.push(
-				await auditPack(
-					pack,
-					{repoName, files},
-					config.model,
-					deps.runner,
-					runnerOptions,
-				),
+			plans.set(
+				pack.manifest.name,
+				deps.cache
+					? decidePackScope({
+							pack,
+							repoDir,
+							cached: deps.cache.entryFor(repoName, pack.manifest.name),
+							dependencies: dependenciesOf(resolvedPacks, pack),
+							incremental: target.incremental,
+							forced: options.full === true,
+							probe: deps.cache.probe,
+						})
+					: {kind: 'full', reason: 'incremental-disabled'},
 			);
 		}
+
+		const fullPacks = resolvedPacks.filter(
+			pack => plans.get(pack.manifest.name)?.kind === 'full',
+		);
+		const files =
+			fullPacks.length > 0
+				? await deps.files.read(repoDir, unionPatterns(fullPacks))
+				: [];
+
+		const packOutcomes: PackOutcome[] = [];
+		const scope = emptyScope();
+		for (const pack of resolvedPacks) {
+			const plan = plans.get(pack.manifest.name);
+			const packFiles =
+				plan?.kind === 'partial'
+					? await deps.files.read(repoDir, plan.paths)
+					: files;
+			if (plan?.kind === 'partial') {
+				scope.scannedByPack.set(
+					pack.manifest.name,
+					new Set(packFiles.map(file => file.path)),
+				);
+			} else {
+				scope.fullPacks.add(pack.manifest.name);
+			}
+			const outcome = await auditPack(
+				pack,
+				{repoName, files: packFiles},
+				config.model,
+				deps.runner,
+				runnerOptions,
+			);
+			packOutcomes.push(outcome);
+			// Only a pass that actually completed may advance the cache. Recording a
+			// commit for a pack whose audit errored would let the next run skip files
+			// on the strength of a pass that never happened.
+			if (outcome.ok && deps.cache) {
+				deps.cache.recordPass(
+					repoName,
+					repoDir,
+					pack,
+					dependenciesOf(resolvedPacks, pack),
+				);
+			}
+		}
+
+		// Only interesting when the operator asked for incremental scanning: a
+		// full pass they did not request needs no explanation.
+		const fullPasses: FullPassNote[] = target.incremental
+			? [...plans.entries()]
+					.filter(([, plan]) => plan.kind === 'full')
+					.map(([pack, plan]) => ({
+						pack,
+						reason: (plan as {reason: FullReason}).reason,
+					}))
+			: [];
 
 		repos.push({
 			repo: repoName,
 			packs: packOutcomes,
 			missingPacks,
 			unresolvedPacks,
+			...(fullPasses.length > 0 ? {fullPasses} : {}),
 		});
 
 		if (!deps.client) {
@@ -176,11 +278,6 @@ export async function runFromConfig(
 				packOfFinding.set(finding, outcome.pack);
 			}
 		}
-		// Every pack read everything it applies to: this path does not skip files
-		// yet, so the scope is complete and reconciliation is unchanged. The
-		// plumbing lands first so that the incremental cache cannot be introduced
-		// without it.
-		const scope = fullScope(packOutcomes.map(outcome => outcome.pack));
 		const override = await readOverride(deps.files, repoDir);
 		const context: FilingContext = {
 			auditedRepo: repoName,

--- a/source/run/run.ts
+++ b/source/run/run.ts
@@ -27,7 +27,7 @@ import type {ModelRunner} from '../orchestrator/types.js';
 import {resolveDependencies} from '../rule-packs/dependencies.js';
 import {parseRulePack} from '../rule-packs/parse.js';
 import type {RulePack} from '../rule-packs/types.js';
-import {auditPack} from './audit.js';
+import {auditPack, skippedPackOutcome} from './audit.js';
 import type {PrepareResult} from './clone.js';
 import {expandTargets} from './expand.js';
 import {
@@ -213,11 +213,18 @@ export async function runFromConfig(
 		const scope = emptyScope();
 		for (const pack of resolvedPacks) {
 			const plan = plans.get(pack.manifest.name);
-			const packFiles =
-				plan?.kind === 'partial'
-					? await deps.files.read(repoDir, plan.paths)
-					: files;
+			let packFiles = files;
 			if (plan?.kind === 'partial') {
+				// `RepoFiles.read` treats an empty pattern list as "the whole
+				// repository", so a pack with nothing to re-read must not be asked to
+				// read at all. Getting this wrong is silent in the worst way: the pack
+				// re-reads everything AND records a scope claiming it scanned
+				// everything, so incremental scanning becomes a no-op that nothing
+				// notices — on the commonest case of all, where nothing changed.
+				packFiles =
+					plan.paths.length === 0
+						? []
+						: await deps.files.read(repoDir, plan.paths);
 				scope.scannedByPack.set(
 					pack.manifest.name,
 					new Set(packFiles.map(file => file.path)),
@@ -225,13 +232,16 @@ export async function runFromConfig(
 			} else {
 				scope.fullPacks.add(pack.manifest.name);
 			}
-			const outcome = await auditPack(
-				pack,
-				{repoName, files: packFiles},
-				config.model,
-				deps.runner,
-				runnerOptions,
-			);
+			const outcome =
+				plan?.kind === 'partial' && packFiles.length === 0
+					? skippedPackOutcome(pack)
+					: await auditPack(
+							pack,
+							{repoName, files: packFiles},
+							config.model,
+							deps.runner,
+							runnerOptions,
+						);
 			packOutcomes.push(outcome);
 			// Only a pass that actually completed may advance the cache. Recording a
 			// commit for a pack whose audit errored would let the next run skip files

--- a/source/run/types.ts
+++ b/source/run/types.ts
@@ -7,6 +7,7 @@
 import type {Finding} from '../findings/types.js';
 import type {ValidationError} from '../findings/validate.js';
 import type {SeverityOverride} from '../findings/weighting.js';
+import type {FullReason} from '../incremental/decide.js';
 import type {SourceFile} from '../prompt/types.js';
 import type {RulePack, RulePackError} from '../rule-packs/types.js';
 
@@ -84,10 +85,24 @@ export interface UnresolvedPack {
 	errors: RulePackError[];
 }
 
+/** A pack that read every file this run, and why it had to. */
+export interface FullPassNote {
+	pack: string;
+	reason: FullReason;
+}
+
 /** All pack outcomes for one repository. */
 export interface RepoOutcome {
 	repo: string;
 	packs: PackOutcome[];
+	/**
+	 * Packs that read everything despite this target asking for incremental
+	 * scanning, and why. Empty when the target did not opt in — a list of
+	 * "incremental is off" for every pack would bury the case that matters,
+	 * which is an operator who turned it on and is wondering why nothing got
+	 * faster.
+	 */
+	fullPasses?: FullPassNote[];
 	/** Packs named by the target but missing from the rule-packs directory. */
 	missingPacks: string[];
 	/** Packs present on disk whose `depends_on` chain failed to resolve. */

--- a/template/.github/workflows/sentinel.yml
+++ b/template/.github/workflows/sentinel.yml
@@ -46,11 +46,15 @@ jobs:
           --output "$GITHUB_STEP_SUMMARY"
           ${{ github.event.inputs.dry_run == 'true' && '--dry-run' || '' }}
 
-      - name: Commit run record and dashboard
+      - name: Commit run record, dashboard and incremental cache
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add runs dashboard
+          # The incremental cache has to survive between runs or every run finds
+          # no cache and re-reads everything — incremental scanning would look
+          # enabled and do nothing. Tolerated when absent: a dry run writes none.
+          git add .sentinel-cache.json || true
           if ! git diff --cached --quiet; then
             git commit -m "chore: sentinel run record [skip ci]"
             git push

--- a/template/README.md
+++ b/template/README.md
@@ -30,4 +30,5 @@ the example block and set its key as an environment variable / Actions secret.
 - `rule-packs/` — your rule packs (you author these).
 - `.github/workflows/sentinel.yml` — the scheduled audit.
 - `runs/` — a committed JSON record per run (the durable history).
+- `.sentinel-cache.json` — what each pack last audited, for incremental runs.
 - `dashboard/` — a generated static `index.html`; serve it via GitHub Pages.


### PR DESCRIPTION
Closes #17. The second half: the cache that makes runs partial, on top of the scope machinery from #34 that makes partial runs safe.

Off by default, opt-in per target.

```yaml
targets:
  - repo: my-org/my-program
    rule_packs: [solana-anchor, rust-general]
    incremental: true
```

## Why this could not land before #34

Skipping unchanged files means a finding in a skipped file is absent from the run. Reconciliation ages out what it does not see. On a daily schedule with `resolve_after_misses: 3`, **turning this on would have auto-closed real, unfixed findings after three runs.**

#34 made the scanned scope reach the planner. This PR is what finally produces a scope that is not complete. There is an end-to-end test for exactly that: an incremental second run whose finding's file is unchanged, with `resolveAfterMisses: 1`, asserting the issue is held and *not* closed. **I confirmed it fails without the scope threading** — the issue gets closed.

## Everything uncertain reads everything

The asymmetry is the whole design. Being wrong about *needing* to re-read costs model time. Being wrong about *not* needing to costs a missed finding and, eventually, an issue closed as fixed. Those are not close, so a full pass happens whenever anything is unclear:

| Situation | Why |
| --- | --- |
| No cached pass | The first run, always |
| Pack version **or body** changed | An edited prompt asks a different question |
| A `depends_on` pack changed | Its body is part of this pack's prompt |
| Cached commit unreachable | Shallow clone, force-push. *Cannot tell* ≠ *nothing changed* |
| `--full` | The escape hatch, always available |

**Body hash, not just version**, because a pack edited in place without a version bump is the likeliest way to get a stale audit. Dependencies are hashed separately from the pack's own body so the report can say which of the two actually changed.

## The details that matter more than the diff suggests

**A failed pack records nothing.** Advancing the cache after an errored pass would let the next run skip files on the strength of an audit that never happened. Tested.

**Untracked files count as changed.** A file added since the last pass and not yet committed has never been audited, and `git diff` will not mention it. Easy to miss, and it would have been a permanent blind spot for any file that stayed uncommitted.

**A repo matching several targets is incremental only if *every* one opted in.** Packs union across targets; the flag does not. An OR would let an unrelated pattern silently cause a target's files to be skipped. Tested in both orders, because a fold like this is exactly where order-dependence hides.

**A dry run neither reads nor writes the cache.** A preview must not narrow a later audit, nor record a pass it did not make.

**The report says which packs re-read everything, and why.** An operator who turns this on and sees no speed-up gets `db-safety: the cached commit is unreachable, so nothing could be diffed` rather than silence. Doing the slow thing quietly is how a setting gets believed to be broken.

**The cache is a committed JSON file** beside the run records — no database, same posture as everything else. Missing, malformed, or written by a newer schema all mean "empty", which means a full read. It never throws: taking down a scheduled audit over the file whose only job is to make it faster would be a poor trade.

## Answering #17's open questions

- **Cache granularity** — per repo+pack, as suggested. Enough for the invalidation rule, and it matches how scope is keyed.
- **`depends_on`** — yes, a dependency's body change forces a full pass for the dependent. Its body is in the prompt.
- **Surfacing held state** — done in #34 (run summary, preview, record, dashboard), and this PR adds the full-pass reasons alongside it.

## Verification

- 496 tests. `incremental/` at **100%** line and branch coverage; project 97.5%.
- The acceptance test was confirmed to fail with the fix disabled.
- Full gate green: types (source and specs), lint, format, knip, `pnpm audit`, Semgrep 0 findings.
- `git.ts` is the only part that shells out and is coverage-excluded by the existing convention; the decision logic takes `GitProbe` as an interface and is fully tested.

## Not done here

Cost estimation already shipped in #14, so with this merged **#1 is fully superseded** and can be closed alongside #17.
